### PR TITLE
Fix the GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-request.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-request.yaml
@@ -3,7 +3,7 @@ name: 🐞 Bug Report
 description: Use this template to report a bug in the Remote Checkin app
 title: "[Bug]: "
 labels:
-  - "ty:bug"
+  - "bug"
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,6 +1,6 @@
 ---
 name: 🛠️ Feature Request
-description: Suggest an idea to help us improve W&B
+description: Suggest an idea to help us improve Remote Checkin app
 title: "[Feature]: "
 labels:
   - "enhancement"

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -3,7 +3,7 @@ name: 🛠️ Feature Request
 description: Suggest an idea to help us improve W&B
 title: "[Feature]: "
 labels:
-  - "ty:feature"
+  - "enhancement"
 
 body:
   - type: markdown


### PR DESCRIPTION
This Pull Request is fixing the issue described in #73:

- Wrong labels used in both bug report and feature request templates
- Wrong app name used in the feature request description field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Refreshed issue templates to improve clarity for contributors.
  * Bug reports now use the “bug” label.
  * Feature requests now use the “enhancement” label.
  * Updated feature request description to reference the Remote Checkin app.

* Chores
  * Standardized GitHub issue labels across templates to streamline triage.
  * No functional changes to the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->