### PR TITLE
fix: resolve permission denied error for log files in Docker

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -18,12 +18,23 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Install Python dependencies
 RUN pip install --upgrade pip && pip install --no-cache-dir -r requirements.txt
 
+# Create necessary directories with proper permissions
+RUN mkdir -p /usr/src/app/logs /usr/src/app/uploads
+
 # Create a non-root user
 RUN groupadd -r appuser && useradd -r -g appuser appuser
 
 # Copy application code while ignoring unnecessary files
 COPY . .
-RUN chown -R appuser:appuser /usr/src/app
+
+# Copy and set up entrypoint script
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# Set proper ownership and permissions
+RUN chown -R appuser:appuser /usr/src/app && \
+    chmod -R 755 /usr/src/app/logs && \
+    chmod -R 755 /usr/src/app/uploads
 
 # Switch to non-root user
 USER appuser
@@ -33,6 +44,9 @@ ENV GUNICORN_CMD_ARGS="--bind=0.0.0.0:8000 --chdir=/usr/src/app"
 
 # Expose the Flask port
 EXPOSE 8000
+
+# Set entrypoint
+ENTRYPOINT ["/entrypoint.sh"]
 
 # Run the application using Gunicorn
 CMD ["gunicorn", "wsgi:app"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -28,7 +28,7 @@ RUN groupadd -r appuser && useradd -r -g appuser appuser
 COPY . .
 
 # Copy and set up entrypoint script
-COPY entrypoint.sh /entrypoint.sh
+COPY backend/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 # Set proper ownership and permissions

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Ensure directories exist and have proper permissions
+mkdir -p /usr/src/app/logs /usr/src/app/uploads
+
+# Set proper permissions for current user (appuser)
+chmod -R 755 /usr/src/app/logs /usr/src/app/uploads
+
+# Execute the main command
+exec "$@"


### PR DESCRIPTION
- Create logs and uploads directories in Dockerfile with proper permissions
- Add entrypoint script to ensure directories exist at runtime
- Set proper ownership and permissions for appuser
- Fix PermissionError: [Errno 13] Permission denied for /usr/src/app/logs/remote-checkin.log

Ensures logging works correctly in Docker container with non-root user.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Prevents startup errors by ensuring required runtime directories exist with correct permissions.
  - Improves reliability of file uploads and log creation.

- Chores
  - Introduces a container entrypoint to standardize app initialization.
  - Sets explicit server binding and startup command for consistent behavior.
  - Streamlines image build by consolidating setup and permission steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->