### PR TITLE
Enforce structure scoping for rooms and reservations

### DIFF
--- a/backend/routes/reservation_routes.py
+++ b/backend/routes/reservation_routes.py
@@ -12,6 +12,7 @@ from datetime import datetime
 
 from flask import Blueprint, request, jsonify
 from sqlalchemy import  func
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.sql import extract
 from flask_jwt_extended import get_jwt_identity, jwt_required
 
@@ -20,7 +21,7 @@ from email_handler import EmailService
 from routes.email_config_routes import get_encryption_key
 from utils.email_utils import get_admin_email_config
 from utils.authz import is_superadmin
-from utils.route_helpers import user_has_structure
+from utils.route_helpers import user_has_structure, get_user_structure_ids
 from app_logging.config import get_logger
 from app_logging.decorators import log_route, log_database_operation, log_performance
 from app_logging.utils import safe_extra_fields, log_notification_error
@@ -112,11 +113,22 @@ def create_reservation():
         if end_date < start_date:
             return jsonify({"error": "endDate must be on or after startDate"}), 400
         # Find room ID by name
-        room = session.query(Room).filter(Room.name == data["roomName"]).first()
+        if is_superadmin():
+            room = session.query(Room).filter(Room.name == data["roomName"]).first()
+        else:
+            allowed_structure_ids = get_user_structure_ids(session, current_user_id)
+            if not allowed_structure_ids:
+                return jsonify({"error": "Access denied for this structure"}), 403
+            room = (
+                session.query(Room)
+                .filter(
+                    Room.name == data["roomName"],
+                    Room.id_structure.in_(allowed_structure_ids)
+                )
+                .first()
+            )
         if not room:
             return jsonify({"error": "Room not found"}), 404
-        if not is_superadmin() and not user_has_structure(session, current_user_id, room.id_structure):
-            return jsonify({"error": "Access denied for this structure"}), 403
 
         # Validate number_of_people if provided - safely coerce to int
         raw_number_of_people = data.get("numberOfPeople", 1)
@@ -474,9 +486,7 @@ def get_reservations_by_structure(structure_id):
         flask.Response: JSON array of reservation objects. If no reservations exist for the structure, an empty list is returned.
     """
     db = SessionLocal()
-    reservations = (
-        []
-    )
+    reservations = []
     try:
         current_user_id = int(get_jwt_identity())
         try:
@@ -490,6 +500,8 @@ def get_reservations_by_structure(structure_id):
             .filter(StructureReservationsView.structure_id == structure_id_int)
             .all()
         )
+    except SQLAlchemyError:
+        return jsonify({"error": "Database error"}), 500
     finally:
         db.close()
     return jsonify([{

--- a/backend/routes/reservation_routes.py
+++ b/backend/routes/reservation_routes.py
@@ -19,6 +19,8 @@ from models import Reservation, Room, Structure, StructureReservationsView, Emai
 from email_handler import EmailService
 from routes.email_config_routes import get_encryption_key
 from utils.email_utils import get_admin_email_config
+from utils.authz import is_superadmin
+from utils.route_helpers import user_has_structure
 from app_logging.config import get_logger
 from app_logging.decorators import log_route, log_database_operation, log_performance
 from app_logging.utils import safe_extra_fields, log_notification_error
@@ -81,6 +83,7 @@ def create_reservation():
     session = SessionLocal()
 
     try:
+        current_user_id = int(get_jwt_identity())
         # Log the received reservation data
         logger.info("Processing reservation creation", extra=safe_extra_fields({
             'reservation_number': data.get('reservationNumber'),
@@ -112,6 +115,8 @@ def create_reservation():
         room = session.query(Room).filter(Room.name == data["roomName"]).first()
         if not room:
             return jsonify({"error": "Room not found"}), 404
+        if not is_superadmin() and not user_has_structure(session, current_user_id, room.id_structure):
+            return jsonify({"error": "Access denied for this structure"}), 403
 
         # Validate number_of_people if provided - safely coerce to int
         raw_number_of_people = data.get("numberOfPeople", 1)
@@ -300,10 +305,16 @@ def update_reservation(reservation_id):
 
     db = SessionLocal()
     try:
+        current_user_id = int(get_jwt_identity())
         reservation = db.query(Reservation).filter(Reservation.id == reservation_id).first()
 
         if not reservation:
             return jsonify({"error": f"Reservation with ID {reservation_id} not found"}), 404
+        current_room = db.query(Room).filter(Room.id == reservation.id_room).first()
+        if not current_room:
+            return jsonify({"error": "Current room not found"}), 404
+        if not is_superadmin() and not user_has_structure(db, current_user_id, current_room.id_structure):
+            return jsonify({"error": "Access denied for this reservation"}), 403
 
         # Optional updates
         if "start_date" in data:
@@ -344,17 +355,16 @@ def update_reservation(reservation_id):
             if new_number_of_people < 1:
                 return jsonify({"error": "Number of people must be at least 1"}), 400
 
-# Determine target room atomically
+        # Determine target room atomically
         if "room" in data and isinstance(data["room"], dict) and "id" in data["room"]:
             # Use new room if provided
             target_room = db.query(Room).filter(Room.id == data["room"]["id"]).first()
             if not target_room:
                 return jsonify({"error": "Target room not found"}), 404
+            if not is_superadmin() and not user_has_structure(db, current_user_id, target_room.id_structure):
+                return jsonify({"error": "Access denied for target room"}), 403
         else:
-            # Use current room if no room change
-            target_room = db.query(Room).filter(Room.id == reservation.id_room).first()
-            if not target_room:
-                return jsonify({"error": "Current room not found"}), 404
+            target_room = current_room
 
         # Validate number_of_people against target room capacity
         if new_number_of_people is not None:
@@ -408,10 +418,16 @@ def delete_reservation(reservation_id):
     """
     db = SessionLocal()
     try:
+        current_user_id = int(get_jwt_identity())
         reservation = db.query(Reservation).filter(Reservation.id == reservation_id).first()
 
         if not reservation:
             return jsonify({"error": f"Reservation with ID {reservation_id} not found"}), 404
+        room = db.query(Room).filter(Room.id == reservation.id_room).first()
+        if not room:
+            return jsonify({"error": "Room not found"}), 404
+        if not is_superadmin() and not user_has_structure(db, current_user_id, room.id_structure):
+            return jsonify({"error": "Access denied for this reservation"}), 403
 
         db.delete(reservation)
         db.commit()
@@ -459,11 +475,23 @@ def get_reservations_by_structure(structure_id):
     """
     db = SessionLocal()
     reservations = (
-        db.query(StructureReservationsView)
-        .filter(StructureReservationsView.structure_id == structure_id)
-        .all()
+        []
     )
-    db.close()
+    try:
+        current_user_id = int(get_jwt_identity())
+        try:
+            structure_id_int = int(structure_id)
+        except (TypeError, ValueError):
+            return jsonify({"error": "Invalid structure_id. Must be an integer."}), 400
+        if not is_superadmin() and not user_has_structure(db, current_user_id, structure_id_int):
+            return jsonify({"error": "Access denied for this structure"}), 403
+        reservations = (
+            db.query(StructureReservationsView)
+            .filter(StructureReservationsView.structure_id == structure_id_int)
+            .all()
+        )
+    finally:
+        db.close()
     return jsonify([{
         "structure_id": r.structure_id,
         "structure_name": r.structure_name,
@@ -495,6 +523,7 @@ def get_admin_reservations_by_id(reservation_id):
     """
     db = SessionLocal()
     try:
+        current_user_id = int(get_jwt_identity())
         reservation = (
             db.query(Reservation)
             .filter(Reservation.id == str(reservation_id))
@@ -503,6 +532,11 @@ def get_admin_reservations_by_id(reservation_id):
 
         if not reservation:
             return jsonify({"error": f"Reservation with ID {reservation_id} not found"}), 404
+        room = db.query(Room).filter(Room.id == reservation.id_room).first()
+        if not room:
+            return jsonify({"error": "Room not found"}), 404
+        if not is_superadmin() and not user_has_structure(db, current_user_id, room.id_structure):
+            return jsonify({"error": "Access denied for this reservation"}), 403
 
         return jsonify(reservation.to_dict())
     except Exception as e:
@@ -578,6 +612,9 @@ def get_reservations_per_month(structure_id):
     """
     db = SessionLocal()
     try:
+        current_user_id = int(get_jwt_identity())
+        if not is_superadmin() and not user_has_structure(db, current_user_id, structure_id):
+            return jsonify({"error": "Access denied for this structure"}), 403
         # Check if the structure exists
         structure = db.query(Structure).filter(Structure.id == structure_id).first()
         if not structure:
@@ -647,6 +684,7 @@ def update_reservation_status(reservation_id):
 
     db = SessionLocal()
     try:
+        current_user_id = int(get_jwt_identity())
         reservation = db.query(Reservation).filter(Reservation.id == str(reservation_id)).first()
 
         if not reservation:
@@ -654,6 +692,10 @@ def update_reservation_status(reservation_id):
 
         # Fetch room separately to avoid lazy loading issues
         room = db.query(Room).filter(Room.id == reservation.id_room).first()
+        if not room:
+            return jsonify({"error": "Room not found"}), 404
+        if not is_superadmin() and not user_has_structure(db, current_user_id, room.id_structure):
+            return jsonify({"error": "Access denied for this reservation"}), 403
 
         old_status = reservation.status
         reservation.status = new_status

--- a/backend/routes/reservation_routes.py
+++ b/backend/routes/reservation_routes.py
@@ -488,7 +488,10 @@ def get_reservations_by_structure(structure_id):
     db = SessionLocal()
     reservations = []
     try:
-        current_user_id = int(get_jwt_identity())
+        try:
+            current_user_id = int(get_jwt_identity())
+        except (TypeError, ValueError):
+            return jsonify({"error": "Invalid user identity"}), 400
         try:
             structure_id_int = int(structure_id)
         except (TypeError, ValueError):

--- a/backend/routes/room_routes.py
+++ b/backend/routes/room_routes.py
@@ -273,6 +273,7 @@ def get_room(room_id):
 @jwt_required()
 @log_route(include_request_data=True, include_response_data=True)
 @log_database_operation("UPDATE")
+# pylint: disable=R0911
 def update_room(room_id):
     """
     Update the details of an existing room by its ID.
@@ -392,12 +393,20 @@ def delete_room(room_id):
         tuple: JSON response and HTTP status code.
     """
     with get_db() as db:  # Again, using 'with' for context management
-        current_user_id = int(get_jwt_identity())
-        room = db.query(Room).filter(Room.id == room_id).first()
+        try:
+            current_user_id = int(get_jwt_identity())
+            room = db.query(Room).filter(Room.id == room_id).first()
 
-        if room:
+            if not room:
+                logger.warning("Room not found for deletion", extra={
+                    'room_id': room_id,
+                    'operation_result': 'not_found'
+                })
+                return jsonify({"error": "Room not found"}), 404
+
             if not is_superadmin() and not user_has_structure(db, current_user_id, room.id_structure):
                 return jsonify({"error": "Access denied for this room"}), 403
+
             # Log deletion attempt with room details
             room_details = {
                 'room_id': room_id,
@@ -408,44 +417,37 @@ def delete_room(room_id):
             }
             logger.info("Attempting room deletion", extra=room_details)
 
-            try:
-                db.delete(room)
-                db.commit()
-                logger.info("Room deleted successfully", extra={
-                    **room_details,
-                    'operation_result': 'success'
-                })
-                return jsonify({"message": "Room deleted successfully"}), 200
-            except IntegrityError as e:
-                db.rollback()
-                logger.error("Room deletion failed due to integrity constraints", extra={
-                    **room_details,
-                    'error_type': 'integrity_constraint',
-                    'error_details': str(e),
-                    'operation_result': 'failed'
-                })
-                return jsonify({"error": f"Failed to delete room due to foreign key constraints: {str(e)}"}), 400
-            except SQLAlchemyError as e:
-                db.rollback()
-                logger.error("Database error during room deletion", extra={
-                    **room_details,
-                    'error_type': 'database_error',
-                    'error_details': str(e),
-                    'operation_result': 'failed'
-                })
-                return jsonify({"error": f"Failed to delete room: {str(e)}"}), 500
-            except (ValueError, TypeError) as e:
-                db.rollback()
-                logger.exception("Unexpected error during room deletion", extra={
-                    **room_details,
-                    'error_type': 'unexpected_error',
-                    'error_details': str(e),
-                    'operation_result': 'failed'
-                }, exc_info=True)
-                return jsonify({"error": "An unexpected error occurred while deleting the room"}), 500
-
-        logger.warning("Room not found for deletion", extra={
-            'room_id': room_id,
-            'operation_result': 'not_found'
-        })
-        return jsonify({"error": "Room not found"}), 404
+            db.delete(room)
+            db.commit()
+            logger.info("Room deleted successfully", extra={
+                **room_details,
+                'operation_result': 'success'
+            })
+            return jsonify({"message": "Room deleted successfully"}), 200
+        except IntegrityError as e:
+            db.rollback()
+            logger.error("Room deletion failed due to integrity constraints", extra={
+                'room_id': room_id,
+                'error_type': 'integrity_constraint',
+                'error_details': str(e),
+                'operation_result': 'failed'
+            })
+            return jsonify({"error": f"Failed to delete room due to foreign key constraints: {str(e)}"}), 400
+        except SQLAlchemyError as e:
+            db.rollback()
+            logger.error("Database error during room deletion", extra={
+                'room_id': room_id,
+                'error_type': 'database_error',
+                'error_details': str(e),
+                'operation_result': 'failed'
+            })
+            return jsonify({"error": f"Failed to delete room: {str(e)}"}), 500
+        except (ValueError, TypeError) as e:
+            db.rollback()
+            logger.exception("Unexpected error during room deletion", extra={
+                'room_id': room_id,
+                'error_type': 'unexpected_error',
+                'error_details': str(e),
+                'operation_result': 'failed'
+            }, exc_info=True)
+            return jsonify({"error": "An unexpected error occurred while deleting the room"}), 500

--- a/backend/routes/room_routes.py
+++ b/backend/routes/room_routes.py
@@ -15,7 +15,7 @@ Each route interacts with the database to perform the necessary actions related 
 """
 
 from flask import Blueprint, request, jsonify
-from flask_jwt_extended import jwt_required
+from flask_jwt_extended import jwt_required, get_jwt_identity
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 
 #pylint: disable=E0611,E0401
@@ -23,6 +23,8 @@ from models import Room, Structure
 from app_logging.config import get_logger
 from app_logging.decorators import log_route, log_database_operation, log_function
 from app_logging.utils import safe_extra_fields
+from utils.authz import is_superadmin
+from utils.route_helpers import get_user_structure_ids, user_has_structure
 from database import get_db  # Use absolute import
 
 # Configure logging
@@ -73,6 +75,7 @@ def add_room():
     """
     with get_db() as db:  # Using the 'with' statement to manage the database session
         data = request.get_json()
+        current_user_id = int(get_jwt_identity())
 
         # Validate the input data
         if (
@@ -85,6 +88,8 @@ def add_room():
                     "error": "Missing required fields: 'name', 'capacity', or 'id_structure'"
                 }
             ), 400
+        if not is_superadmin() and not user_has_structure(db, current_user_id, data["id_structure"]):
+            return jsonify({"error": "Access denied for this structure"}), 403
 
         # Create a new room
         new_room = Room(
@@ -157,6 +162,7 @@ def get_rooms():
     """
     with get_db() as db:  # Using 'with' to properly manage the db session
         try:
+            current_user_id = int(get_jwt_identity())
             raw_structure_id = request.args.get("structure_id")
             id_structure = None
             if raw_structure_id is not None:
@@ -166,9 +172,22 @@ def get_rooms():
                     return jsonify({"error": "Invalid structure_id. Must be an integer."}), 400
 
             if id_structure is not None:
+                if not is_superadmin() and not user_has_structure(db, current_user_id, id_structure):
+                    return jsonify({"error": "Access denied for this structure"}), 403
                 rooms = db.query(Room).filter(Room.id_structure == id_structure).order_by(Room.id).all()
             else:
-                rooms = db.query(Room).order_by(Room.id).all()  # Return all rooms if no structure is specified
+                if is_superadmin():
+                    rooms = db.query(Room).order_by(Room.id).all()
+                else:
+                    allowed_structure_ids = get_user_structure_ids(db, current_user_id)
+                    if not allowed_structure_ids:
+                        return jsonify([])
+                    rooms = (
+                        db.query(Room)
+                        .filter(Room.id_structure.in_(allowed_structure_ids))
+                        .order_by(Room.id)
+                        .all()
+                    )
 
             room_data = [room.to_dict() for room in rooms]
             logger.info("Rooms retrieved successfully", extra={
@@ -213,8 +232,11 @@ def get_room(room_id):
     """
     with get_db() as db:  # Using 'with' statement here as well
         try:
+            current_user_id = int(get_jwt_identity())
             room = db.query(Room).filter(Room.id == room_id).first()
             if room:
+                if not is_superadmin() and not user_has_structure(db, current_user_id, room.id_structure):
+                    return jsonify({"error": "Access denied for this room"}), 403
                 logger.info("Room retrieved successfully", extra={
                     'room_id': room_id,
                     'room_name': room.name,
@@ -265,6 +287,7 @@ def update_room(room_id):
     """
     with get_db() as db:
         try:
+            current_user_id = int(get_jwt_identity())
             room = db.query(Room).filter(Room.id == room_id).first()
             if not room:
                 logger.warning("Room not found for update", extra={
@@ -272,6 +295,8 @@ def update_room(room_id):
                     'operation_result': 'not_found'
                 })
                 return jsonify({"error": "Room not found"}), 404
+            if not is_superadmin() and not user_has_structure(db, current_user_id, room.id_structure):
+                return jsonify({"error": "Access denied for this room"}), 403
 
             data = request.get_json()
 
@@ -293,6 +318,9 @@ def update_room(room_id):
                     'operation_result': 'validation_failed'
                 })
                 return jsonify({"error": validation_error}), 400
+            if "id_structure" in data and not is_superadmin():
+                if not user_has_structure(db, current_user_id, data["id_structure"]):
+                    return jsonify({"error": "Access denied for this structure"}), 403
 
             # Track what fields are being updated
             updated_fields = {}
@@ -364,9 +392,12 @@ def delete_room(room_id):
         tuple: JSON response and HTTP status code.
     """
     with get_db() as db:  # Again, using 'with' for context management
+        current_user_id = int(get_jwt_identity())
         room = db.query(Room).filter(Room.id == room_id).first()
 
         if room:
+            if not is_superadmin() and not user_has_structure(db, current_user_id, room.id_structure):
+                return jsonify({"error": "Access denied for this room"}), 403
             # Log deletion attempt with room details
             room_details = {
                 'room_id': room_id,

--- a/backend/utils/authz.py
+++ b/backend/utils/authz.py
@@ -79,3 +79,14 @@ def verify_superadmin_access():
         return jsonify({"error": PERMISSION_ERROR}), 403
 
     return None, None
+
+
+def is_superadmin() -> bool:
+    """
+    Return True if the current JWT has the superadmin role.
+    """
+    try:
+        claims = get_jwt()
+        return claims.get("role", "").lower() == "superadmin"
+    except Exception:
+        return False

--- a/backend/utils/route_helpers.py
+++ b/backend/utils/route_helpers.py
@@ -146,6 +146,33 @@ def get_user_structures_query(db_session, user_id):
     )
 
 
+def get_user_structure_ids(db_session, user_id):
+    """
+    Return a list of structure IDs associated with the given user.
+    """
+    rows = (
+        db_session.query(AdminStructure.id_structure)
+        .filter(AdminStructure.id_user == user_id)
+        .all()
+    )
+    return [row.id_structure for row in rows]
+
+
+def user_has_structure(db_session, user_id, structure_id):
+    """
+    Return True if the user is associated with the given structure ID.
+    """
+    return (
+        db_session.query(AdminStructure)
+        .filter(
+            AdminStructure.id_user == user_id,
+            AdminStructure.id_structure == structure_id
+        )
+        .first()
+        is not None
+    )
+
+
 def create_user_response_data(new_user, role):
     """
     Create standardized user response data.


### PR DESCRIPTION
Why
Admins could access rooms/reservations across structures if they knew IDs. Access control was only enforced in the frontend.

What changed

Added helper functions to check structure ownership and superadmin bypass.
Enforced structure scoping in:
Room create/list/get/update/delete
Reservation create/update/delete/get/admin-get/status/monthly/structure-list
Invalid structure IDs now return 400, unauthorized access returns 403.
Notes

Superadmin retains full access.
Public reservation check endpoint remains unchanged.
Testing

Not run (API layer only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced per-user authorization across reservation and room endpoints so users only view/modify resources in structures they manage; super-admins retain broader access.
  * Added utility helpers to determine a user's assigned structures and super-admin status.

* **Bug Fixes**
  * Improved error handling and responses: consistent 403 for forbidden access, 404 for missing rooms, and clearer database error paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->