### PR TITLE
test(frontend): expand Playwright smoke coverage + stabilize i18n/runtime behavior

### DIFF
--- a/.github/workflows/frontend-e2e.yml
+++ b/.github/workflows/frontend-e2e.yml
@@ -1,0 +1,49 @@
+name: Frontend E2E Smoke
+
+on:
+  pull_request:
+    branches:
+      - dev
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  e2e-smoke:
+    name: Run Playwright Smoke Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        run: |
+          cd frontend
+          npm ci
+
+      - name: Install Playwright browser
+        run: |
+          cd frontend
+          npx playwright install --with-deps chromium
+
+      - name: Run smoke e2e suite
+        run: |
+          cd frontend
+          npm run e2e:smoke
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-smoke-report-pr-${{ github.event.pull_request.number }}
+          path: frontend/playwright-report/
+          retention-days: 7

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -1,0 +1,44 @@
+name: Frontend Tests
+
+on:
+  pull_request:
+    branches:
+      - dev
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  test-frontend:
+    name: Validate Frontend Unit Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: |
+          cd frontend
+          npm ci
+
+      - name: Run frontend test suite
+        run: |
+          cd frontend
+          npm run test:ci
+
+      - name: Upload frontend coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-coverage-pr-${{ github.event.pull_request.number }}
+          path: frontend/coverage/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -187,3 +187,4 @@ frontend/package-lock.json
 backend/tests/reports/
 frontend/playwright-report/
 frontend/test-results/
+frontend/coverage/

--- a/.gitignore
+++ b/.gitignore
@@ -188,3 +188,4 @@ backend/tests/reports/
 frontend/playwright-report/
 frontend/test-results/
 frontend/coverage/
+uploads/

--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,6 @@ report.xml
 frontend/package-lock.json
 /backend/uploads
 .env.backup
+backend/tests/reports/
+frontend/playwright-report/
+frontend/test-results/

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -106,6 +106,7 @@
         "test": {
           "builder": "@angular-devkit/build-angular:karma",
           "options": {
+            "karmaConfig": "karma.conf.js",
             "polyfills": [
               "zone.js",
               "zone.js/testing"

--- a/frontend/karma.conf.js
+++ b/frontend/karma.conf.js
@@ -1,0 +1,37 @@
+// Karma configuration file for frontend unit tests.
+module.exports = function (config) {
+  config.set({
+    basePath: '',
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage'),
+      require('@angular-devkit/build-angular/plugins/karma')
+    ],
+    client: {
+      jasmine: {},
+      clearContext: false
+    },
+    jasmineHtmlReporter: {
+      suppressAll: true
+    },
+    coverageReporter: {
+      dir: require('path').join(__dirname, './coverage/remote-checkin'),
+      subdir: '.',
+      reporters: [{ type: 'html' }, { type: 'text-summary' }, { type: 'lcovonly' }],
+      check: {
+        global: {
+          statements: 40,
+          branches: 30,
+          functions: 40,
+          lines: 40
+        }
+      }
+    },
+    reporters: ['progress', 'kjhtml'],
+    browsers: ['ChromeHeadless'],
+    restartOnFileChange: true
+  });
+};

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -34,6 +34,7 @@
         "@angular-devkit/build-angular": "^19.1.5",
         "@angular/cli": "^19.1.5",
         "@angular/compiler-cli": "^19.1.3",
+        "@playwright/test": "^1.55.0",
         "@types/express": "^4.17.17",
         "@types/jasmine": "~5.1.0",
         "@types/node": "^18.18.0",
@@ -4504,6 +4505,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@primeng/themes": {
@@ -11314,6 +11331,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
-    "test:ci": "ng test --watch=false --browsers=ChromeHeadless --code-coverage --include=\"src/app/guards/**/*.spec.ts\" --include=\"src/app/services/**/*.spec.ts\" --include=\"src/app/app.component.spec.ts\"",
+    "test:ci": "ng test --watch=false --browsers=ChromeHeadless --code-coverage --include=\"src/app/guards/**/*.spec.ts\" --include=\"src/app/services/**/*.spec.ts\" --include=\"src/app/admin/dashboard/dashboard.component.spec.ts\" --include=\"src/app/admin/room/room.component.spec.ts\" --include=\"src/app/app.component.spec.ts\"",
     "serve:ssr:remote-checkin": "node dist/remote-checkin/server/server.mjs"
   },
   "private": true,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
+    "test:ci": "ng test --watch=false --browsers=ChromeHeadless --code-coverage --include=\"src/app/guards/**/*.spec.ts\" --include=\"src/app/services/**/*.spec.ts\" --include=\"src/app/app.component.spec.ts\"",
     "serve:ssr:remote-checkin": "node dist/remote-checkin/server/server.mjs"
   },
   "private": true,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
     "test:ci": "ng test --watch=false --browsers=ChromeHeadless --code-coverage --include=\"src/app/guards/**/*.spec.ts\" --include=\"src/app/services/**/*.spec.ts\" --include=\"src/app/admin/dashboard/dashboard.component.spec.ts\" --include=\"src/app/admin/room/room.component.spec.ts\" --include=\"src/app/app.component.spec.ts\"",
+    "e2e:smoke": "playwright test --config=playwright.config.ts",
     "serve:ssr:remote-checkin": "node dist/remote-checkin/server/server.mjs"
   },
   "private": true,
@@ -35,6 +36,7 @@
     "zone.js": "~0.15.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.55.0",
     "@angular-devkit/build-angular": "^19.1.5",
     "@angular/cli": "^19.1.5",
     "@angular/compiler-cli": "^19.1.3",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  timeout: 30_000,
+  expect: { timeout: 5_000 },
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
+  use: {
+    baseURL: 'http://127.0.0.1:4200',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure'
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] }
+    }
+  ],
+  webServer: {
+    command: 'npm start -- --host 127.0.0.1 --port 4200',
+    url: 'http://127.0.0.1:4200',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000
+  }
+});

--- a/frontend/src/app/admin/change-password/change-password.component.spec.ts
+++ b/frontend/src/app/admin/change-password/change-password.component.spec.ts
@@ -1,0 +1,98 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { of, throwError } from 'rxjs';
+
+import { TranslocoService } from '@jsverse/transloco';
+import { AdminInfoService } from '../../services/admin-info.service';
+import { ChangePasswordComponent } from './change-password.component';
+
+describe('ChangePasswordComponent', () => {
+  let component: ChangePasswordComponent;
+  let fixture: ComponentFixture<ChangePasswordComponent>;
+  let adminInfoService: jasmine.SpyObj<AdminInfoService>;
+  let router: jasmine.SpyObj<Router>;
+
+  beforeEach(async () => {
+    adminInfoService = jasmine.createSpyObj<AdminInfoService>('AdminInfoService', ['changePassword']);
+    router = jasmine.createSpyObj<Router>('Router', ['navigate']);
+
+    await TestBed.configureTestingModule({
+      imports: [ChangePasswordComponent],
+      providers: [
+        { provide: AdminInfoService, useValue: adminInfoService },
+        { provide: Router, useValue: router },
+        {
+          provide: TranslocoService,
+          useValue: {
+            translate: (key: string) => key,
+            getActiveLang: () => 'en',
+            langChanges$: of('en'),
+            config: {
+              reRenderOnLangChange: false
+            }
+          }
+        }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ChangePasswordComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should not submit when form is invalid', () => {
+    component.form.patchValue({
+      currentPassword: '',
+      newPassword: 'weak',
+      confirmPassword: 'weak'
+    });
+
+    component.onSubmit();
+
+    expect(adminInfoService.changePassword).not.toHaveBeenCalled();
+  });
+
+  it('should submit valid form and reset on success', () => {
+    adminInfoService.changePassword.and.returnValue(of({ message: 'ok' }));
+    component.form.patchValue({
+      currentPassword: 'Oldpass123',
+      newPassword: 'Newpass123',
+      confirmPassword: 'Newpass123'
+    });
+
+    component.onSubmit();
+
+    expect(adminInfoService.changePassword).toHaveBeenCalledWith({
+      current_password: 'Oldpass123',
+      new_password: 'Newpass123',
+      confirm_password: 'Newpass123'
+    });
+    expect(component.successMessage).toBe('change-password-success');
+    expect(component.errorMessage).toBe('');
+  });
+
+  it('should expose backend error message when available', () => {
+    adminInfoService.changePassword.and.returnValue(
+      throwError(() => ({ error: { error: 'Current password is incorrect' } }))
+    );
+    component.form.patchValue({
+      currentPassword: 'wrong',
+      newPassword: 'Newpass123',
+      confirmPassword: 'Newpass123'
+    });
+
+    component.onSubmit();
+
+    expect(component.errorMessage).toBe('Current password is incorrect');
+    expect(component.successMessage).toBe('');
+  });
+
+  it('goBack should navigate to admin dashboard', () => {
+    component.goBack();
+    expect(router.navigate).toHaveBeenCalledWith(['/admin/dashboard']);
+  });
+});

--- a/frontend/src/app/admin/dashboard/dashboard.component.spec.ts
+++ b/frontend/src/app/admin/dashboard/dashboard.component.spec.ts
@@ -1,23 +1,114 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
 
 import { DashboardComponent } from './dashboard.component';
+import { ReservationService } from '../../services/reservation.service';
+import { AuthService } from '../../services/auth.service';
+import { MessageService } from 'primeng/api';
+import { TranslocoService } from '@jsverse/transloco';
 
 describe('DashboardComponent', () => {
   let component: DashboardComponent;
   let fixture: ComponentFixture<DashboardComponent>;
+  let messageService: jasmine.SpyObj<MessageService>;
+
+  const reservationServiceStub = jasmine.createSpyObj('ReservationService', [
+    'getReservationByStructureId',
+    'getMonthlyReservation'
+  ]);
+  const authServiceStub = {
+    getUser: () => ({ structures: [{ id: 1, name: 'Main' }] })
+  };
+  const translocoStub = {
+    translate: (key: string) => key,
+    selectTranslateObject: () => of([])
+  };
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [DashboardComponent]
-    })
-    .compileComponents();
+    reservationServiceStub.getReservationByStructureId.and.returnValue(of([]));
+    reservationServiceStub.getMonthlyReservation.and.returnValue(of([]));
+    messageService = jasmine.createSpyObj('MessageService', ['add']);
 
+    await TestBed.configureTestingModule({
+      imports: [DashboardComponent],
+      providers: [
+        { provide: ReservationService, useValue: reservationServiceStub },
+        { provide: AuthService, useValue: authServiceStub },
+        { provide: MessageService, useValue: messageService },
+        { provide: TranslocoService, useValue: translocoStub }
+      ]
+    })
+      .overrideComponent(DashboardComponent, { set: { template: '' } })
+      .compileComponents();
+
+    localStorage.setItem('selected_structure_id', '1');
     fixture = TestBed.createComponent(DashboardComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
 
+  afterEach(() => {
+    localStorage.clear();
+  });
+
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should apply status and room filters and keep only matching rows', () => {
+    component.reservations = [
+      { id_reference: 'A-1', name_reference: 'Mario', room_name: 'Room A', status: 'Pending', start_date: '2026-01-03' },
+      { id_reference: 'B-1', name_reference: 'Luigi', room_name: 'Room B', status: 'Approved', start_date: '2026-01-04' }
+    ];
+
+    component.statusFilter = 'Pending';
+    component.roomFilter = 'Room A';
+    component.applyFilters();
+
+    expect(component.filteredReservations.length).toBe(1);
+    expect(component.filteredReservations[0].id_reference).toBe('A-1');
+  });
+
+  it('should apply global search case-insensitively', () => {
+    component.reservations = [
+      { id_reference: 'RES-001', name_reference: 'John Doe', room_name: 'Blue', status: 'Pending', start_date: '2026-01-03' },
+      { id_reference: 'RES-002', name_reference: 'Jane Doe', room_name: 'Red', status: 'Approved', start_date: '2026-01-04' }
+    ];
+
+    component.globalSearchTerm = 'jane';
+    component.applyFilters();
+
+    expect(component.filteredReservations.length).toBe(1);
+    expect(component.filteredReservations[0].id_reference).toBe('RES-002');
+  });
+
+  it('should update recent reservations from active filter source only', () => {
+    component.reservations = [
+      { id_reference: 'RES-001', name_reference: 'A', room_name: 'X', status: 'Pending', start_date: '2026-01-01' },
+      { id_reference: 'RES-002', name_reference: 'B', room_name: 'Y', status: 'Approved', start_date: '2026-01-10' },
+      { id_reference: 'RES-003', name_reference: 'C', room_name: 'Y', status: 'Pending', start_date: '2026-01-12' }
+    ];
+
+    component.statusFilter = 'Pending';
+    component.applyFilters();
+
+    expect(component.filteredReservations.length).toBe(2);
+    expect(component.recentReservations.length).toBe(2);
+    expect(component.recentReservations[0].id_reference).toBe('RES-003');
+    expect(component.recentReservations[1].id_reference).toBe('RES-001');
+  });
+
+  it('should clear all filters', () => {
+    component.statusFilter = 'Pending';
+    component.dateRangeFilter = 'week';
+    component.roomFilter = 'Room A';
+    component.globalSearchTerm = 'foo';
+
+    component.clearFilters();
+
+    expect(component.statusFilter).toBe('');
+    expect(component.dateRangeFilter).toBe('');
+    expect(component.roomFilter).toBe('');
+    expect(component.globalSearchTerm).toBe('');
   });
 });

--- a/frontend/src/app/admin/room/room.component.spec.ts
+++ b/frontend/src/app/admin/room/room.component.spec.ts
@@ -1,163 +1,111 @@
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+
 import { RoomComponent } from './room.component';
 import { RoomService } from '../../services/room.service';
-import { ConfirmationService, MessageService } from 'primeng/api';
-import { of, throwError } from 'rxjs';
-import { TableModule } from 'primeng/table';
-import { ButtonModule } from 'primeng/button';
-import { InputTextModule } from 'primeng/inputtext';
-import { FormsModule } from '@angular/forms';
-import { CommonModule } from '@angular/common';
-import { ToastModule } from 'primeng/toast';
-import { SelectModule } from 'primeng/select';
-import { ConfirmDialogModule } from 'primeng/confirmdialog';
-import { DialogModule } from 'primeng/dialog';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { TranslocoService } from '@jsverse/transloco';
 import { AuthService } from '../../services/auth.service';
+import { TranslocoService } from '@jsverse/transloco';
 
 describe('RoomComponent', () => {
   let component: RoomComponent;
   let fixture: ComponentFixture<RoomComponent>;
-  let mockRoomService: jasmine.SpyObj<RoomService>;
+  let roomService: jasmine.SpyObj<RoomService>;
 
   beforeEach(async () => {
-    mockRoomService = jasmine.createSpyObj('RoomService', ['getRooms', 'editRoom', 'deleteRoom', 'addRoom']);
+    roomService = jasmine.createSpyObj('RoomService', ['getRooms', 'editRoom', 'deleteRoom', 'addRoom']);
+    roomService.getRooms.and.returnValue(of([{ id: 1, name: 'Room A', capacity: 2, is_active: true }]));
+    roomService.editRoom.and.returnValue(of({}));
+    roomService.addRoom.and.returnValue(of({ id: 2, name: 'Room B', capacity: 3, is_active: true }));
+    roomService.deleteRoom.and.returnValue(of({}));
 
     await TestBed.configureTestingModule({
-      imports: [
-        RoomComponent,
-        TableModule,
-        ButtonModule,
-        InputTextModule,
-        SelectModule,
-        CommonModule,
-        ToastModule,
-        ConfirmDialogModule,
-        DialogModule,
-        FormsModule,
-        NoopAnimationsModule
-      ],
+      imports: [RoomComponent],
       providers: [
-        { provide: RoomService, useValue: mockRoomService },
-        { provide: AuthService, useValue: { getUser: () => ({ structures: [] }) } },
-        { provide: TranslocoService, useValue: { translate: (key: string) => key } },
-        MessageService,
-        ConfirmationService
+        { provide: RoomService, useValue: roomService },
+        {
+          provide: AuthService,
+          useValue: {
+            getUser: () => ({ structures: [{ id: 1, name: 'Main' }] })
+          }
+        },
+        { provide: TranslocoService, useValue: { translate: (key: string) => key } }
       ]
-    }).compileComponents();
+    })
+      .overrideComponent(RoomComponent, { set: { template: '' } })
+      .compileComponents();
 
+    localStorage.setItem('selected_structure_id', '1');
     fixture = TestBed.createComponent(RoomComponent);
     component = fixture.componentInstance;
-
-    // ✅ Ensure `getRooms` is always returning an observable
-    mockRoomService.getRooms.and.returnValue(of([]));
-
     fixture.detectChanges();
   });
 
-  it('should create the component', () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('should create', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should fetch rooms on initialization', () => {
-    const mockRooms = [{ id: 1, name: 'Deluxe', capacity: 2 }];
-    mockRoomService.getRooms.and.returnValue(of(mockRooms));
-
-    component.ngOnInit(); // Manually trigger ngOnInit
-    fixture.detectChanges();
-
-    expect(mockRoomService.getRooms).toHaveBeenCalled();
-    expect(component.rooms[0].name).toEqual('Deluxe');
+  it('should load rooms and initialize filtered list', () => {
+    expect(roomService.getRooms).toHaveBeenCalledWith(1);
+    expect(component.rooms.length).toBe(1);
+    expect(component.filteredRooms.length).toBe(1);
+    expect(component.filteredRooms[0].name).toBe('Room A');
   });
 
-  it('should handle error when fetching rooms', () => {
-    const messageService = TestBed.inject(MessageService);
-    spyOn(messageService, 'add');
-    mockRoomService.getRooms.and.returnValue(throwError(() => new Error('Failed to fetch rooms')));
+  it('should filter rooms by search term', () => {
+    component.rooms = [
+      { id: 1, name: 'Blue', capacity: 2, isActive: true },
+      { id: 2, name: 'Red', capacity: 4, isActive: true }
+    ];
+    component.searchTerm = 'red';
 
-    component.ngOnInit();
-    fixture.detectChanges();
+    (component as any).applyFilters();
 
-    expect(messageService.add).toHaveBeenCalled();
+    expect(component.filteredRooms.length).toBe(1);
+    expect(component.filteredRooms[0].name).toBe('Red');
   });
 
-  it('should edit a room successfully', fakeAsync(() => {
-    const mockRoom = { id: 1, name: 'Deluxe', capacity: 2 };
-    mockRoomService.editRoom.and.returnValue(of(mockRoom));
+  it('should toggle room status and persist success', () => {
+    const room = { id: 1, name: 'Blue', capacity: 2, isActive: true, is_active: true };
+    roomService.editRoom.and.returnValue(of({}));
 
-    component.onRowEditSave(mockRoom);
-    tick(); // Simulate async passage of time
+    component.toggleRoomStatus(room);
 
-    expect(mockRoomService.editRoom).toHaveBeenCalledWith(mockRoom);
-  }));
+    expect(roomService.editRoom).toHaveBeenCalled();
+    expect(room.isActive).toBeFalse();
+    expect(room.is_active).toBeFalse();
+  });
 
-  it('should handle error when editing a room', fakeAsync(() => {
-    const messageService = TestBed.inject(MessageService);
-    spyOn(messageService, 'add');
-    const mockRoom = { id: 1, name: 'Deluxe', capacity: 2 };
-    mockRoomService.editRoom.and.returnValue(throwError(() => new Error('Failed to edit room')));
+  it('should rollback status toggle on API error', () => {
+    const room = { id: 1, name: 'Blue', capacity: 2, isActive: true, is_active: true };
+    roomService.editRoom.and.returnValue(throwError(() => new Error('boom')));
+    const addSpy = spyOn((component as any).messageService, 'add');
 
-    component.onRowEditSave(mockRoom);
-    tick();
+    component.toggleRoomStatus(room);
 
-    expect(messageService.add).toHaveBeenCalled();
-  }));
+    expect(room.isActive).toBeTrue();
+    expect(room.is_active).toBeTrue();
+    expect(addSpy).toHaveBeenCalled();
+  });
 
-  it('should delete a room successfully', fakeAsync(() => {
-    const mockRoom = { id: 1, name: 'Deluxe', capacity: 2 };
-    const mockEvent = new Event('click');
-    mockRoomService.deleteRoom.and.returnValue(of({ message: 'Room deleted successfully' }));
-
-    // Mock confirmation dialog behavior
-    spyOn(component.confirmationService, 'confirm').and.callFake((confirmation) => {
-      // Directly calling accept to simulate user confirming the deletion
-      return confirmation.accept!();
-    });
-
-    component.onRowDelete(mockRoom, 0, mockEvent);
-    tick(); // Simulate async passage of time
-
-    expect(mockRoomService.deleteRoom).toHaveBeenCalledWith(mockRoom.id);
-  }));
-
-
-  it('should handle error when deleting a room', fakeAsync(() => {
-    spyOn(console, 'error');
-    const mockRoom = { id: 1, name: 'Deluxe', capacity: 2 };
-    const mockEvent = new Event('click');
-    mockRoomService.deleteRoom.and.returnValue(throwError(() => new Error('Failed to delete room')));
-
-    spyOn(component.confirmationService, 'confirm').and.callFake((confirmation) => confirmation.accept!());
-
-    component.onRowDelete(mockRoom, 0, mockEvent);
-    tick();
-
-    expect(mockRoomService.deleteRoom).toHaveBeenCalledWith(mockRoom.id);
-
-    expect(console.error).toHaveBeenCalledWith('Error deleting reservations:', jasmine.any(Error));
-  }));
-
-  it('should add a room successfully', fakeAsync(() => {
-    const newRoom = { name: 'Suite', capacity: 3 };
-    mockRoomService.addRoom.and.returnValue(of(newRoom));
-
-    component.new_room = newRoom;
+  it('should create room and append it to list', () => {
+    component.new_room = { name: 'Suite', capacity: 3, id_structure: 1, is_active: true };
     component.addRoom();
-    tick();
 
-    expect(mockRoomService.addRoom).toHaveBeenCalledWith(newRoom);
-  }));
+    expect(roomService.addRoom).toHaveBeenCalled();
+    expect(component.rooms.some((r) => r.name === 'Room B')).toBeTrue();
+  });
 
-  it('should handle error when adding a room', fakeAsync(() => {
-    spyOn(console, 'error');
-    const newRoom = { name: 'Suite', capacity: 3 };
-    mockRoomService.addRoom.and.returnValue(throwError(() => new Error('Failed to add room')));
+  it('should delete room when confirmation is accepted', () => {
+    component.rooms = [{ id: 1, name: 'Room A', capacity: 2, isActive: true }];
+    spyOn(component.confirmationService, 'confirm').and.callFake((cfg: any) => cfg.accept());
 
-    component.new_room = newRoom;
-    component.addRoom();
-    tick();
+    component.onRowDelete(component.rooms[0], 0, new Event('click'));
 
-    expect(console.error).toHaveBeenCalledWith('Error adding reservations:', jasmine.any(Error));
-  }));
+    expect(roomService.deleteRoom).toHaveBeenCalledWith(1);
+    expect(component.rooms.length).toBe(0);
+  });
 });

--- a/frontend/src/app/admin/superadmin/associations/associations.component.spec.ts
+++ b/frontend/src/app/admin/superadmin/associations/associations.component.spec.ts
@@ -1,0 +1,39 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+
+import { SuperadminAssociationsComponent } from './associations.component';
+import { SuperadminService } from '../../../services/superadmin.service';
+
+describe('SuperadminAssociationsComponent', () => {
+  let component: SuperadminAssociationsComponent;
+  let fixture: ComponentFixture<SuperadminAssociationsComponent>;
+  let service: jasmine.SpyObj<SuperadminService>;
+
+  beforeEach(async () => {
+    service = jasmine.createSpyObj('SuperadminService', ['getAssociations', 'getUsers', 'getStructures']);
+    service.getAssociations.and.returnValue(of({ associations: [] }));
+    service.getUsers.and.returnValue(of({ users: [] }));
+    service.getStructures.and.returnValue(of({ structures: [] }));
+
+    await TestBed.configureTestingModule({
+      imports: [SuperadminAssociationsComponent],
+      providers: [{ provide: SuperadminService, useValue: service }]
+    })
+      .overrideComponent(SuperadminAssociationsComponent, { set: { template: '' } })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(SuperadminAssociationsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should load initial datasets on init', () => {
+    expect(service.getAssociations).toHaveBeenCalled();
+    expect(service.getUsers).toHaveBeenCalled();
+    expect(service.getStructures).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/admin/superadmin/structures/structures.component.spec.ts
+++ b/frontend/src/app/admin/superadmin/structures/structures.component.spec.ts
@@ -1,0 +1,46 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+
+import { SuperadminStructuresComponent } from './structures.component';
+import { SuperadminService } from '../../../services/superadmin.service';
+import { ErrorHandlerService } from '../../../services/error-handler.service';
+
+describe('SuperadminStructuresComponent', () => {
+  let component: SuperadminStructuresComponent;
+  let fixture: ComponentFixture<SuperadminStructuresComponent>;
+  let service: jasmine.SpyObj<SuperadminService>;
+
+  beforeEach(async () => {
+    service = jasmine.createSpyObj('SuperadminService', [
+      'getStructures',
+      'createStructure',
+      'updateStructure',
+      'deleteStructure',
+      'restoreStructure'
+    ]);
+    service.getStructures.and.returnValue(of({ structures: [], pagination: { page: 1 } }));
+
+    await TestBed.configureTestingModule({
+      imports: [SuperadminStructuresComponent],
+      providers: [
+        { provide: SuperadminService, useValue: service },
+        { provide: ErrorHandlerService, useValue: { getErrorMessageString: () => 'error' } }
+      ]
+    })
+      .overrideComponent(SuperadminStructuresComponent, { set: { template: '' } })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(SuperadminStructuresComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should load structures on init', () => {
+    expect(service.getStructures).toHaveBeenCalled();
+    expect(component.loading).toBeFalse();
+  });
+});

--- a/frontend/src/app/admin/superadmin/superadmin-dashboard/superadmin-dashboard.component.spec.ts
+++ b/frontend/src/app/admin/superadmin/superadmin-dashboard/superadmin-dashboard.component.spec.ts
@@ -1,0 +1,47 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+
+import { SuperadminDashboardComponent } from './superadmin-dashboard.component';
+import { SuperadminService } from '../../../services/superadmin.service';
+
+describe('SuperadminDashboardComponent', () => {
+  let component: SuperadminDashboardComponent;
+  let fixture: ComponentFixture<SuperadminDashboardComponent>;
+  let service: jasmine.SpyObj<SuperadminService>;
+
+  beforeEach(async () => {
+    service = jasmine.createSpyObj('SuperadminService', ['getDashboardData']);
+    service.getDashboardData.and.returnValue(of({
+      dashboard: {
+        total_structures: 1,
+        active_structures: 1,
+        archived_structures: 0,
+        total_users: 1,
+        admin_users: 1,
+        superadmin_users: 0,
+        unassigned_admins: 0,
+        total_reservations: 0
+      }
+    }));
+
+    await TestBed.configureTestingModule({
+      imports: [SuperadminDashboardComponent],
+      providers: [{ provide: SuperadminService, useValue: service }]
+    })
+      .overrideComponent(SuperadminDashboardComponent, { set: { template: '' } })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(SuperadminDashboardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should request dashboard data on init', () => {
+    expect(service.getDashboardData).toHaveBeenCalled();
+    expect(component.loading).toBeFalse();
+  });
+});

--- a/frontend/src/app/admin/superadmin/superadmin.component.spec.ts
+++ b/frontend/src/app/admin/superadmin/superadmin.component.spec.ts
@@ -1,0 +1,37 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { BehaviorSubject } from 'rxjs';
+import { provideRouter } from '@angular/router';
+
+import { SuperadminComponent } from './superadmin.component';
+import { AuthService } from '../../services/auth.service';
+
+describe('SuperadminComponent', () => {
+  let component: SuperadminComponent;
+  let fixture: ComponentFixture<SuperadminComponent>;
+  const user$ = new BehaviorSubject<any>({ id: 1, role: 'superadmin' });
+  const authServiceStub = {
+    user$,
+    isLoggedIn: () => true,
+    isSuperAdmin: () => true
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SuperadminComponent],
+      providers: [
+        provideRouter([]),
+        { provide: AuthService, useValue: authServiceStub }
+      ]
+    })
+      .overrideComponent(SuperadminComponent, { set: { template: '' } })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(SuperadminComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/src/app/admin/superadmin/users/users.component.spec.ts
+++ b/frontend/src/app/admin/superadmin/users/users.component.spec.ts
@@ -1,0 +1,51 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+
+import { SuperadminUsersComponent } from './users.component';
+import { SuperadminService } from '../../../services/superadmin.service';
+import { ErrorHandlerService } from '../../../services/error-handler.service';
+import { TranslocoService } from '@jsverse/transloco';
+
+describe('SuperadminUsersComponent', () => {
+  let component: SuperadminUsersComponent;
+  let fixture: ComponentFixture<SuperadminUsersComponent>;
+  let service: jasmine.SpyObj<SuperadminService>;
+
+  beforeEach(async () => {
+    service = jasmine.createSpyObj('SuperadminService', [
+      'getUsers',
+      'getRoles',
+      'getStructures',
+      'createUser',
+      'updateUser',
+      'resetUserPassword',
+      'createAssociation',
+      'deleteAssociation',
+      'changeUserRole'
+    ]);
+    service.getUsers.and.returnValue(of({ users: [], pagination: { page: 1 } }));
+
+    await TestBed.configureTestingModule({
+      imports: [SuperadminUsersComponent],
+      providers: [
+        { provide: SuperadminService, useValue: service },
+        { provide: ErrorHandlerService, useValue: { getErrorMessageString: () => 'error' } },
+        { provide: TranslocoService, useValue: { translate: (key: string) => key } }
+      ]
+    })
+      .overrideComponent(SuperadminUsersComponent, { set: { template: '' } })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(SuperadminUsersComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should load users on init', () => {
+    expect(service.getUsers).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/app.component.spec.ts
+++ b/frontend/src/app/app.component.spec.ts
@@ -17,13 +17,6 @@ describe('AppComponent', () => {
   it(`should have the 'remote-checkin' title`, () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;
-    expect(app.title).toEqual('remote-checkin');
-  });
-
-  it('should render title', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
-    const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, remote-checkin');
+    expect(app.title).toEqual('Remote Check-in');
   });
 });

--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -42,6 +42,11 @@ export const appConfig: ApplicationConfig = {
         availableLangs: ['en', 'es', 'it', 'fr', 'de'],
         defaultLang: 'en',
         fallbackLang: 'en',
+        missingHandler: {
+          logMissingKey: false,
+          useFallbackTranslation: true,
+          allowEmpty: true
+        },
         // Remove this option if your application doesn't support changing language in runtime.
         reRenderOnLangChange: true,
         prodMode: !isDevMode(),

--- a/frontend/src/app/checkin-complete/checkin-complete.component.spec.ts
+++ b/frontend/src/app/checkin-complete/checkin-complete.component.spec.ts
@@ -1,0 +1,37 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, convertToParamMap } from '@angular/router';
+
+import { CheckinCompleteComponent } from './checkin-complete.component';
+
+describe('CheckinCompleteComponent', () => {
+  let component: CheckinCompleteComponent;
+  let fixture: ComponentFixture<CheckinCompleteComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CheckinCompleteComponent],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: { paramMap: convertToParamMap({ id: '123' }) }
+          }
+        }
+      ]
+    })
+      .overrideComponent(CheckinCompleteComponent, { set: { template: '' } })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(CheckinCompleteComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should read reservation id from route', () => {
+    expect(component.reservationId).toBe('123');
+  });
+});

--- a/frontend/src/app/faq/faq.component.spec.ts
+++ b/frontend/src/app/faq/faq.component.spec.ts
@@ -1,0 +1,30 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { FAQComponent } from './faq.component';
+
+describe('FAQComponent', () => {
+  let component: FAQComponent;
+  let fixture: ComponentFixture<FAQComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FAQComponent]
+    })
+      .overrideComponent(FAQComponent, { set: { template: '' } })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(FAQComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should toggle FAQ item expansion', () => {
+    expect(component.categories[0].items[0].expanded).toBeFalse();
+    component.toggleItem(0, 0);
+    expect(component.categories[0].items[0].expanded).toBeTrue();
+  });
+});

--- a/frontend/src/app/guards/auth.guard.spec.ts
+++ b/frontend/src/app/guards/auth.guard.spec.ts
@@ -1,0 +1,39 @@
+import { TestBed } from '@angular/core/testing';
+import { provideRouter, Router, UrlTree } from '@angular/router';
+
+import { AuthService } from '../services/auth.service';
+import { authGuard } from './auth.guard';
+
+describe('authGuard', () => {
+  let router: Router;
+  const authServiceStub = {
+    isLoggedIn: () => false
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([]),
+        { provide: AuthService, useValue: authServiceStub }
+      ]
+    });
+    router = TestBed.inject(Router);
+  });
+
+  it('should redirect to /admin/login when not logged in', () => {
+    spyOn(authServiceStub, 'isLoggedIn').and.returnValue(false);
+    const result = TestBed.runInInjectionContext(() =>
+      authGuard({} as any, { url: '/admin/dashboard' } as any)
+    );
+    expect(result instanceof UrlTree).toBeTrue();
+    expect(router.serializeUrl(result as UrlTree)).toBe('/admin/login');
+  });
+
+  it('should allow access when logged in', () => {
+    spyOn(authServiceStub, 'isLoggedIn').and.returnValue(true);
+    const result = TestBed.runInInjectionContext(() =>
+      authGuard({} as any, { url: '/admin/dashboard' } as any)
+    );
+    expect(result).toBeTrue();
+  });
+});

--- a/frontend/src/app/guards/superadmin.guard.spec.ts
+++ b/frontend/src/app/guards/superadmin.guard.spec.ts
@@ -1,0 +1,51 @@
+import { TestBed } from '@angular/core/testing';
+import { provideRouter, Router, UrlTree } from '@angular/router';
+
+import { AuthService } from '../services/auth.service';
+import { superadminGuard } from './superadmin.guard';
+
+describe('superadminGuard', () => {
+  let router: Router;
+  const authServiceStub = {
+    isLoggedIn: () => false,
+    isSuperAdmin: () => false
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([]),
+        { provide: AuthService, useValue: authServiceStub }
+      ]
+    });
+    router = TestBed.inject(Router);
+  });
+
+  it('should redirect to /admin/login when user is not logged in', () => {
+    spyOn(authServiceStub, 'isLoggedIn').and.returnValue(false);
+    const result = TestBed.runInInjectionContext(() =>
+      superadminGuard({} as any, { url: '/admin/superadmin' } as any)
+    );
+    expect(result instanceof UrlTree).toBeTrue();
+    expect(router.serializeUrl(result as UrlTree)).toBe('/admin/login');
+  });
+
+  it('should redirect to /admin/dashboard when not superadmin', () => {
+    spyOn(authServiceStub, 'isLoggedIn').and.returnValue(true);
+    spyOn(authServiceStub, 'isSuperAdmin').and.returnValue(false);
+    const result = TestBed.runInInjectionContext(() =>
+      superadminGuard({} as any, { url: '/admin/superadmin' } as any)
+    );
+    expect(result instanceof UrlTree).toBeTrue();
+    expect(router.serializeUrl(result as UrlTree)).toBe('/admin/dashboard');
+  });
+
+  it('should allow access for superadmin', () => {
+    spyOn(authServiceStub, 'isLoggedIn').and.returnValue(true);
+    spyOn(authServiceStub, 'isSuperAdmin').and.returnValue(true);
+    const result = TestBed.runInInjectionContext(() =>
+      superadminGuard({} as any, { url: '/admin/superadmin' } as any)
+    );
+    expect(result).toBeTrue();
+  });
+});

--- a/frontend/src/app/landing/landing.component.spec.ts
+++ b/frontend/src/app/landing/landing.component.spec.ts
@@ -1,0 +1,30 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LandingComponent } from './landing.component';
+
+describe('LandingComponent', () => {
+  let component: LandingComponent;
+  let fixture: ComponentFixture<LandingComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [LandingComponent]
+    })
+      .overrideComponent(LandingComponent, { set: { template: '' } })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(LandingComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should dismiss sticky CTA', () => {
+    expect(component.showStickyCta()).toBeTrue();
+    component.dismissStickyCta();
+    expect(component.showStickyCta()).toBeFalse();
+  });
+});

--- a/frontend/src/app/pricing-details/pricing-details.component.html
+++ b/frontend/src/app/pricing-details/pricing-details.component.html
@@ -33,7 +33,15 @@
         <h2>{{ plan.nameKey | transloco }}</h2>
         <p>{{ plan.descriptionKey | transloco }}</p>
         <div class="plan-card__price">
-          <span>{{ getPriceForPlan(plan) }}</span>
+          <ng-container *ngIf="plan.monthly === 0 && plan.annual === 0; else paidPrice">
+            <span>{{ 'pricingDetails.pricing.free' | transloco }}</span>
+          </ng-container>
+          <ng-template #paidPrice>
+            <span>
+              {{ 'pricingDetails.pricing.currencySymbol' | transloco }}{{ getAmountForPlan(plan) }}{{ (billing() ===
+              'monthly' ? 'pricingDetails.pricing.perMonth' : 'pricingDetails.pricing.perYear') | transloco }}
+            </span>
+          </ng-template>
           <small *ngIf="billing() === 'annual' && plan.monthly !== 0">
             {{ 'pricingDetails.pricing.save' | transloco:{ amount: (plan.monthly * 12 - plan.annual) |
             currency:'USD':'symbol':'1.0-0' } }}
@@ -69,19 +77,19 @@
           <ng-container *ngIf="isFeatureIncluded(row.launch); else launchText">
             <i class="pi pi-check"></i>
           </ng-container>
-          <ng-template #launchText>{{ displayFeatureValue(row.launch) }}</ng-template>
+          <ng-template #launchText>{{ getFeatureValueKey(row.launch) | transloco }}</ng-template>
         </div>
         <div class="comparison__cell" role="cell">
           <ng-container *ngIf="isFeatureIncluded(row.growth); else growthText">
             <i class="pi pi-check"></i>
           </ng-container>
-          <ng-template #growthText>{{ displayFeatureValue(row.growth) }}</ng-template>
+          <ng-template #growthText>{{ getFeatureValueKey(row.growth) | transloco }}</ng-template>
         </div>
         <div class="comparison__cell" role="cell">
           <ng-container *ngIf="isFeatureIncluded(row.enterprise); else enterpriseText">
             <i class="pi pi-check"></i>
           </ng-container>
-          <ng-template #enterpriseText>{{ displayFeatureValue(row.enterprise) }}</ng-template>
+          <ng-template #enterpriseText>{{ getFeatureValueKey(row.enterprise) | transloco }}</ng-template>
         </div>
       </div>
     </div>

--- a/frontend/src/app/pricing-details/pricing-details.component.spec.ts
+++ b/frontend/src/app/pricing-details/pricing-details.component.spec.ts
@@ -1,0 +1,48 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PricingDetailsComponent } from './pricing-details.component';
+import { TranslocoService } from '@jsverse/transloco';
+
+describe('PricingDetailsComponent', () => {
+  let component: PricingDetailsComponent;
+  let fixture: ComponentFixture<PricingDetailsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PricingDetailsComponent],
+      providers: [
+        {
+          provide: TranslocoService,
+          useValue: {
+            translate: (key: string) => {
+              const map: Record<string, string> = {
+                'pricingDetails.pricing.currencySymbol': '$',
+                'pricingDetails.pricing.perMonth': '/mo',
+                'pricingDetails.pricing.perYear': '/yr',
+                'pricingDetails.pricing.free': 'Free',
+                'pricingDetails.comparison.value.included': 'Included',
+                'pricingDetails.comparison.value.notIncluded': 'Not included'
+              };
+              return map[key] || key;
+            }
+          }
+        }
+      ]
+    })
+      .overrideComponent(PricingDetailsComponent, { set: { template: '' } })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(PricingDetailsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should return free label for free plan', () => {
+    const freePlan = component.plans[0];
+    expect(component.getPriceForPlan(freePlan)).toBe('Free');
+  });
+});

--- a/frontend/src/app/pricing-details/pricing-details.component.spec.ts
+++ b/frontend/src/app/pricing-details/pricing-details.component.spec.ts
@@ -1,7 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { PricingDetailsComponent } from './pricing-details.component';
-import { TranslocoService } from '@jsverse/transloco';
 
 describe('PricingDetailsComponent', () => {
   let component: PricingDetailsComponent;
@@ -9,25 +8,7 @@ describe('PricingDetailsComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [PricingDetailsComponent],
-      providers: [
-        {
-          provide: TranslocoService,
-          useValue: {
-            translate: (key: string) => {
-              const map: Record<string, string> = {
-                'pricingDetails.pricing.currencySymbol': '$',
-                'pricingDetails.pricing.perMonth': '/mo',
-                'pricingDetails.pricing.perYear': '/yr',
-                'pricingDetails.pricing.free': 'Free',
-                'pricingDetails.comparison.value.included': 'Included',
-                'pricingDetails.comparison.value.notIncluded': 'Not included'
-              };
-              return map[key] || key;
-            }
-          }
-        }
-      ]
+      imports: [PricingDetailsComponent]
     })
       .overrideComponent(PricingDetailsComponent, { set: { template: '' } })
       .compileComponents();
@@ -41,8 +22,8 @@ describe('PricingDetailsComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should return free label for free plan', () => {
+  it('should return zero amount for free plan', () => {
     const freePlan = component.plans[0];
-    expect(component.getPriceForPlan(freePlan)).toBe('Free');
+    expect(component.getAmountForPlan(freePlan)).toBe(0);
   });
 });

--- a/frontend/src/app/pricing-details/pricing-details.component.ts
+++ b/frontend/src/app/pricing-details/pricing-details.component.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { Component, signal } from '@angular/core';
 import { RouterModule } from '@angular/router';
-import { TranslocoPipe, TranslocoService } from '@jsverse/transloco';
+import { TranslocoPipe } from '@jsverse/transloco';
 import { HeaderComponent } from '../shared/header/header.component';
 import { LANDING_NAV_LINKS } from '../shared/navigation';
 
@@ -176,33 +176,21 @@ export class PricingDetailsComponent {
     this.billing.set(cycle);
   }
 
-  getPriceForPlan(plan: PricingPlan): string {
-    const cycle = this.billing();
-    const amount = cycle === 'monthly' ? plan.monthly : plan.annual;
-
-    if (plan.monthly === 0 && plan.annual === 0) {
-      return this.transloco.translate('pricingDetails.pricing.free');
-    }
-
-    const prefix = this.transloco.translate('pricingDetails.pricing.currencySymbol');
-    const suffixKey = cycle === 'monthly' ? 'pricingDetails.pricing.perMonth' : 'pricingDetails.pricing.perYear';
-    const suffix = this.transloco.translate(suffixKey);
-    return `${prefix}${amount}${suffix}`;
+  getAmountForPlan(plan: PricingPlan): number {
+    return this.billing() === 'monthly' ? plan.monthly : plan.annual;
   }
 
   isFeatureIncluded(value: boolean | string): boolean {
     return value === true;
   }
 
-  displayFeatureValue(value: boolean | string): string {
+  getFeatureValueKey(value: boolean | string): string {
     if (typeof value === 'string') {
-      return this.transloco.translate(value);
+      return value;
     }
     if (value) {
-      return this.transloco.translate('pricingDetails.comparison.value.included');
+      return 'pricingDetails.comparison.value.included';
     }
-    return this.transloco.translate('pricingDetails.comparison.value.notIncluded');
+    return 'pricingDetails.comparison.value.notIncluded';
   }
-
-  constructor(private readonly transloco: TranslocoService) { }
 }

--- a/frontend/src/app/services/admin-login.service.spec.ts
+++ b/frontend/src/app/services/admin-login.service.spec.ts
@@ -1,16 +1,48 @@
 import { TestBed } from '@angular/core/testing';
-
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { AdminLoginService } from './admin-login.service';
+import { environment } from '../../environments/environments';
 
 describe('AdminLoginService', () => {
   let service: AdminLoginService;
+  let httpMock: HttpTestingController;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()]
+    });
     service = TestBed.inject(AdminLoginService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('should post login payload', () => {
+    service.login('admin', 'password').subscribe((response) => {
+      expect(response.access_token).toBe('token');
+      expect(response.user.username).toBe('admin');
+    });
+
+    const req = httpMock.expectOne(`${environment.apiBaseUrl}/api/v1/admin/login`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ username: 'admin', password: 'password' });
+    req.flush({
+      access_token: 'token',
+      user: {
+        id: 1,
+        username: 'admin',
+        name: 'Admin',
+        surname: 'User',
+        structures: [],
+        role: 'administrator'
+      }
+    });
   });
 });

--- a/frontend/src/app/services/auth.service.spec.ts
+++ b/frontend/src/app/services/auth.service.spec.ts
@@ -38,4 +38,14 @@ describe('AuthService', () => {
     localStorage.setItem('admin_token', buildToken(Math.floor(Date.now() / 1000) + 600));
     expect(service.isLoggedIn()).toBeTrue();
   });
+
+  it('should return false for malformed token payload', () => {
+    localStorage.setItem('admin_token', 'not.a.jwt');
+    expect(service.isTokenValid()).toBeFalse();
+  });
+
+  it('should return empty auth headers when token is missing', () => {
+    localStorage.removeItem('admin_token');
+    expect(service.getAuthHeaders().keys().length).toBe(0);
+  });
 });

--- a/frontend/src/app/services/auth.service.spec.ts
+++ b/frontend/src/app/services/auth.service.spec.ts
@@ -1,0 +1,41 @@
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { AuthService } from './auth.service';
+
+function buildToken(expSeconds: number): string {
+  const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const payload = btoa(JSON.stringify({ exp: expSeconds }));
+  return `${header}.${payload}.signature`;
+}
+
+describe('AuthService', () => {
+  let service: AuthService;
+
+  beforeEach(() => {
+    localStorage.clear();
+    TestBed.configureTestingModule({
+      providers: [provideRouter([])]
+    });
+    service = TestBed.inject(AuthService);
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('should return false when token is missing', () => {
+    localStorage.removeItem('admin_token');
+    expect(service.isTokenValid()).toBeFalse();
+  });
+
+  it('should return false when token is expired', () => {
+    localStorage.setItem('admin_token', buildToken(Math.floor(Date.now() / 1000) - 5));
+    expect(service.isTokenValid()).toBeFalse();
+  });
+
+  it('should report logged-in when user exists and token is valid', () => {
+    localStorage.setItem('user', JSON.stringify({ id: 1, role: 'administrator' }));
+    localStorage.setItem('admin_token', buildToken(Math.floor(Date.now() / 1000) + 600));
+    expect(service.isLoggedIn()).toBeTrue();
+  });
+});

--- a/frontend/src/app/services/client-reservation.service.spec.ts
+++ b/frontend/src/app/services/client-reservation.service.spec.ts
@@ -1,16 +1,49 @@
 import { TestBed } from '@angular/core/testing';
+import { HttpHeaders, provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 
 import { ClientReservationService } from './client-reservation.service';
+import { AuthService } from './auth.service';
+import { environment } from '../../environments/environments';
 
 describe('ClientReservationService', () => {
   let service: ClientReservationService;
+  let httpMock: HttpTestingController;
+
+  const authHeaders = new HttpHeaders({ Authorization: 'Bearer test-token' });
+  const authServiceStub = {
+    checkAuthAndRedirect: () => true,
+    getAuthHeaders: () => authHeaders
+  };
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: AuthService, useValue: authServiceStub }
+      ]
+    });
     service = TestBed.inject(ClientReservationService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('should get clients by reservation id with auth headers', () => {
+    service.getClientByReservationId(7).subscribe((res) => {
+      expect(res).toEqual([{ id: 1 }]);
+    });
+
+    const req = httpMock.expectOne(`${environment.apiBaseUrl}/api/v1/reservations/7/clients`);
+    expect(req.request.method).toBe('GET');
+    expect(req.request.headers.get('Authorization')).toBe('Bearer test-token');
+    req.flush([{ id: 1 }]);
   });
 });

--- a/frontend/src/app/services/reservation.service.spec.ts
+++ b/frontend/src/app/services/reservation.service.spec.ts
@@ -1,59 +1,74 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpHeaders, provideHttpClient } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+
+import { environment } from '../../environments/environments';
+import { AuthService } from './auth.service';
 import { ReservationService } from './reservation.service';
-import { ReactiveFormsModule } from '@angular/forms';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { By } from '@angular/platform-browser';
-import { of } from 'rxjs';
-import { CreateReservationComponent } from '../admin/create-reservation/create-reservation.component';
 
-describe('CreateReservationComponent', () => {
-  let component: CreateReservationComponent;
-  let fixture: ComponentFixture<CreateReservationComponent>;
-  let reservationService: ReservationService;
+describe('ReservationService', () => {
+  let service: ReservationService;
+  let httpMock: HttpTestingController;
+  let checkAuthAndRedirectSpy: jasmine.Spy;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [CreateReservationComponent],
-      imports: [ReactiveFormsModule, HttpClientTestingModule],
-      providers: [ReservationService],
-    }).compileComponents();
-  });
+  const authHeaders = new HttpHeaders({ Authorization: 'Bearer test-token' });
+  const authServiceStub = {
+    checkAuthAndRedirect: () => true,
+    getAuthHeaders: () => authHeaders
+  };
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(CreateReservationComponent);
-    component = fixture.componentInstance;
-    reservationService = TestBed.inject(ReservationService);
-    fixture.detectChanges();
-  });
+    checkAuthAndRedirectSpy = spyOn(authServiceStub, 'checkAuthAndRedirect').and.returnValue(true);
 
-  it('should create the component', () => {
-    expect(component).toBeTruthy();
-  });
-
-  it('should call the createReservation method of the service when form is valid', () => {
-    const spy = spyOn(reservationService, 'createReservation').and.returnValue(of({}));
-
-    // Set up form values
-    component.reservationForm.setValue({
-      reservationNumber: '123',
-      startDate: '2025-02-01',
-      endDate: '2025-02-05',
-      roomName: 'Deluxe Suite',
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: AuthService, useValue: authServiceStub }
+      ]
     });
 
-    // Trigger form submit
-    component.onSubmit();
-
-    // Verify the service was called
-    expect(spy).toHaveBeenCalled();
+    service = TestBed.inject(ReservationService);
+    httpMock = TestBed.inject(HttpTestingController);
   });
 
-  it('should display error message if form is invalid', () => {
-    // Trigger submit with empty form
-    component.onSubmit();
+  afterEach(() => {
+    httpMock.verify();
+  });
 
-    // Check if validation error message is displayed
-    const errorMessages = fixture.debugElement.queryAll(By.css('.p-error'));
-    expect(errorMessages.length).toBeGreaterThan(0);
+  it('should create a reservation when authenticated', () => {
+    const payload = { roomName: 'A1' };
+
+    service.createReservation(payload).subscribe((res) => {
+      expect(res).toEqual({ id: 1 });
+    });
+
+    const req = httpMock.expectOne(`${environment.apiBaseUrl}/api/v1/reservations`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.headers.get('Authorization')).toBe('Bearer test-token');
+    expect(req.request.body).toEqual(payload);
+    req.flush({ id: 1 });
+  });
+
+  it('should not call API when auth check fails', () => {
+    checkAuthAndRedirectSpy.and.returnValue(false);
+
+    service.createReservation({}).subscribe({
+      next: () => fail('Expected auth failure'),
+      error: (error) => expect(String(error.message)).toContain('Authentication failed')
+    });
+
+    httpMock.expectNone(`${environment.apiBaseUrl}/api/v1/reservations`);
+  });
+
+  it('should fetch monthly reservations with auth header', () => {
+    service.getMonthlyReservation(3).subscribe((res) => {
+      expect(res).toEqual([{ month: 'Jan', total_reservations: 5 }]);
+    });
+
+    const req = httpMock.expectOne(`${environment.apiBaseUrl}/api/v1/reservations/monthly/3`);
+    expect(req.request.method).toBe('GET');
+    expect(req.request.headers.get('Authorization')).toBe('Bearer test-token');
+    req.flush([{ month: 'Jan', total_reservations: 5 }]);
   });
 });

--- a/frontend/src/app/services/superadmin.service.spec.ts
+++ b/frontend/src/app/services/superadmin.service.spec.ts
@@ -1,0 +1,64 @@
+import { HttpHeaders } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+
+import { environment } from '../../environments/environments';
+import { AuthService } from './auth.service';
+import { SuperadminService } from './superadmin.service';
+
+describe('SuperadminService', () => {
+  let service: SuperadminService;
+  let httpMock: HttpTestingController;
+
+  const authHeaders = new HttpHeaders({ Authorization: 'Bearer test-token' });
+  const authServiceStub = {
+    getAuthHeaders: () => authHeaders
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: AuthService, useValue: authServiceStub }
+      ]
+    });
+
+    service = TestBed.inject(SuperadminService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should build structures URL with filters', () => {
+    service.getStructures({ page: 2, per_page: 20, search: 'rome', is_active: 'true' }).subscribe();
+
+    const req = httpMock.expectOne(
+      `${environment.apiBaseUrl}/api/v1/superadmin/structures?page=2&per_page=20&search=rome&is_active=true`
+    );
+    expect(req.request.method).toBe('GET');
+    expect(req.request.headers.get('Authorization')).toBe('Bearer test-token');
+    req.flush({ structures: [] });
+  });
+
+  it('should send delete association payload in request body', () => {
+    service.deleteAssociation(11, 22).subscribe();
+
+    const req = httpMock.expectOne(`${environment.apiBaseUrl}/api/v1/superadmin/associations`);
+    expect(req.request.method).toBe('DELETE');
+    expect(req.request.body).toEqual({ user_id: 11, structure_id: 22 });
+    req.flush({ message: 'ok' });
+  });
+
+  it('should call change-role endpoint with id_role payload', () => {
+    service.changeUserRole(5, 2).subscribe();
+
+    const req = httpMock.expectOne(`${environment.apiBaseUrl}/api/v1/superadmin/users/5/change-role`);
+    expect(req.request.method).toBe('PUT');
+    expect(req.request.body).toEqual({ id_role: 2 });
+    req.flush({ message: 'ok' });
+  });
+});

--- a/frontend/src/app/services/upload.service.spec.ts
+++ b/frontend/src/app/services/upload.service.spec.ts
@@ -1,16 +1,39 @@
 import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 
 import { UploadService } from './upload.service';
+import { environment } from '../../environments/environments';
 
 describe('UploadService', () => {
   let service: UploadService;
+  let httpMock: HttpTestingController;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()]
+    });
     service = TestBed.inject(UploadService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('should send upload token header when provided', () => {
+    const formData = new FormData();
+    formData.append('foo', 'bar');
+
+    service.uploadImages(formData, 'upload-token').subscribe();
+
+    const req = httpMock.expectOne(`${environment.apiBaseUrl}/api/v1/upload`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.headers.get('X-Upload-Token')).toBe('upload-token');
+    req.flush({ ok: true });
   });
 });

--- a/frontend/src/app/shared/header/header.component.spec.ts
+++ b/frontend/src/app/shared/header/header.component.spec.ts
@@ -1,0 +1,45 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { PLATFORM_ID } from '@angular/core';
+
+import { HeaderComponent } from './header.component';
+import { TranslocoService } from '@jsverse/transloco';
+
+describe('HeaderComponent', () => {
+  let component: HeaderComponent;
+  let fixture: ComponentFixture<HeaderComponent>;
+  let transloco: { setActiveLang: jasmine.Spy; getActiveLang: jasmine.Spy };
+
+  beforeEach(async () => {
+    transloco = {
+      setActiveLang: jasmine.createSpy('setActiveLang'),
+      getActiveLang: jasmine.createSpy('getActiveLang').and.returnValue('en')
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [HeaderComponent],
+      providers: [
+        { provide: PLATFORM_ID, useValue: 'browser' },
+        { provide: TranslocoService, useValue: transloco }
+      ]
+    })
+      .overrideComponent(HeaderComponent, { set: { template: '' } })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(HeaderComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    localStorage.removeItem('remote-checkin-lang');
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should set language when supported code is selected', () => {
+    component.changeLanguage('it');
+    expect(transloco.setActiveLang).toHaveBeenCalledWith('it');
+  });
+});

--- a/frontend/src/assets/i18n/de.json
+++ b/frontend/src/assets/i18n/de.json
@@ -489,5 +489,21 @@
   "rooms-csv-skip-detail": "Zimmer {{name}} konnte nicht importiert werden.",
   "rooms-csv-read-error": "CSV-Datei konnte nicht gelesen werden.",
   "portale-alloggi-not-configured": "Portale Alloggi ist nicht konfiguriert. Bitte konfigurieren Sie es zuerst in den Einstellungen.",
-  "upload-token-missing": "Fortfahren nicht möglich: Sicherheits-Upload-Token fehlt. Bitte aktualisieren und erneut versuchen."
+  "upload-token-missing": "Fortfahren nicht möglich: Sicherheits-Upload-Token fehlt. Bitte aktualisieren und erneut versuchen.",
+  "pricingDetails": {
+    "pricing": {
+      "currencySymbol": "€",
+      "perMonth": "/Monat",
+      "perYear": "/Jahr",
+      "free": "Kostenlos"
+    },
+    "comparison": {
+      "value": {
+        "unlimited": "Unbegrenzt",
+        "limited": "Begrenzt",
+        "included": "Inbegriffen",
+        "notIncluded": "—"
+      }
+    }
+  }
 }

--- a/frontend/src/assets/i18n/de.json
+++ b/frontend/src/assets/i18n/de.json
@@ -495,7 +495,8 @@
       "currencySymbol": "€",
       "perMonth": "/Monat",
       "perYear": "/Jahr",
-      "free": "Kostenlos"
+      "free": "Kostenlos",
+      "save": "Sie sparen {{ amount }}"
     },
     "comparison": {
       "value": {
@@ -505,5 +506,9 @@
         "notIncluded": "—"
       }
     }
-  }
+  },
+  "gender-male": "Männlich",
+  "gender-female": "Weiblich",
+  "registration-unavailable": "Registrierung nicht verfügbar",
+  "capacity-verification-failed": "Die Kapazität kann derzeit nicht geprüft werden. Bitte versuchen Sie es später erneut."
 }

--- a/frontend/src/assets/i18n/es.json
+++ b/frontend/src/assets/i18n/es.json
@@ -489,5 +489,21 @@
   "rooms-csv-skip-detail": "No se pudo importar la habitación {{name}}.",
   "rooms-csv-read-error": "No se pudo leer el archivo CSV.",
   "portale-alloggi-not-configured": "Portale Alloggi no está configurado. Configúralo primero en Ajustes.",
-  "upload-token-missing": "No se puede continuar: falta el token de seguridad de carga. Actualiza la página e inténtalo de nuevo."
+  "upload-token-missing": "No se puede continuar: falta el token de seguridad de carga. Actualiza la página e inténtalo de nuevo.",
+  "pricingDetails": {
+    "pricing": {
+      "currencySymbol": "€",
+      "perMonth": "/mes",
+      "perYear": "/año",
+      "free": "Gratis"
+    },
+    "comparison": {
+      "value": {
+        "unlimited": "Ilimitado",
+        "limited": "Limitado",
+        "included": "Incluido",
+        "notIncluded": "—"
+      }
+    }
+  }
 }

--- a/frontend/src/assets/i18n/es.json
+++ b/frontend/src/assets/i18n/es.json
@@ -495,7 +495,8 @@
       "currencySymbol": "€",
       "perMonth": "/mes",
       "perYear": "/año",
-      "free": "Gratis"
+      "free": "Gratis",
+      "save": "Ahorra {{ amount }}"
     },
     "comparison": {
       "value": {
@@ -505,5 +506,9 @@
         "notIncluded": "—"
       }
     }
-  }
+  },
+  "gender-male": "Masculino",
+  "gender-female": "Femenino",
+  "registration-unavailable": "Registro no disponible",
+  "capacity-verification-failed": "No se puede verificar la capacidad ahora. Inténtalo de nuevo más tarde."
 }

--- a/frontend/src/assets/i18n/fr.json
+++ b/frontend/src/assets/i18n/fr.json
@@ -495,7 +495,8 @@
       "currencySymbol": "€",
       "perMonth": "/mois",
       "perYear": "/an",
-      "free": "Gratuit"
+      "free": "Gratuit",
+      "save": "Économisez {{ amount }}"
     },
     "comparison": {
       "value": {
@@ -505,5 +506,9 @@
         "notIncluded": "—"
       }
     }
-  }
+  },
+  "gender-male": "Masculin",
+  "gender-female": "Féminin",
+  "registration-unavailable": "Inscription indisponible",
+  "capacity-verification-failed": "Impossible de vérifier la capacité pour le moment. Veuillez réessayer plus tard."
 }

--- a/frontend/src/assets/i18n/fr.json
+++ b/frontend/src/assets/i18n/fr.json
@@ -489,5 +489,21 @@
   "rooms-csv-skip-detail": "Impossible d'importer la chambre {{name}}.",
   "rooms-csv-read-error": "Impossible de lire le fichier CSV.",
   "portale-alloggi-not-configured": "Portale Alloggi n'est pas configuré. Configurez-le d'abord dans les Paramètres.",
-  "upload-token-missing": "Impossible de continuer : le jeton de sécurité d'envoi est manquant. Actualisez la page puis réessayez."
+  "upload-token-missing": "Impossible de continuer : le jeton de sécurité d'envoi est manquant. Actualisez la page puis réessayez.",
+  "pricingDetails": {
+    "pricing": {
+      "currencySymbol": "€",
+      "perMonth": "/mois",
+      "perYear": "/an",
+      "free": "Gratuit"
+    },
+    "comparison": {
+      "value": {
+        "unlimited": "Illimité",
+        "limited": "Limité",
+        "included": "Inclus",
+        "notIncluded": "—"
+      }
+    }
+  }
 }

--- a/frontend/tests/e2e/smoke.spec.ts
+++ b/frontend/tests/e2e/smoke.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Frontend smoke', () => {
+  test('landing page renders core sections and CTA links', async ({ page }) => {
+    await page.goto('/landing');
+    await expect(page.locator('app-header .app-header')).toBeVisible();
+    await expect(page.locator('section.hero')).toBeVisible();
+    await expect(page.locator('section.features')).toBeVisible();
+
+    const pricingCta = page.locator('.hero__cta .btn--primary');
+    const loginCta = page.locator('.hero__cta .btn--ghost');
+
+    await expect(pricingCta).toBeVisible();
+    await expect(loginCta).toBeVisible();
+    await expect(pricingCta).toHaveAttribute('href', '/pricing');
+    await expect(loginCta).toHaveAttribute('href', '/admin/login');
+  });
+
+  test('admin login page renders expected form controls', async ({ page }) => {
+    await page.goto('/admin/login');
+    await expect(page.locator('form')).toBeVisible();
+    await expect(page.locator('#username')).toBeVisible();
+    await expect(page.locator('#password')).toBeVisible();
+    await expect(page.locator('button[type="submit"]').first()).toBeVisible();
+  });
+
+  test('pricing page renders plan section', async ({ page }) => {
+    await page.goto('/pricing');
+    await expect(page.locator('app-header .app-header')).toBeVisible();
+    await expect(page.locator('.pricing')).toBeVisible();
+    await expect(page.locator('.plans')).toBeVisible();
+  });
+});

--- a/frontend/tests/e2e/smoke.spec.ts
+++ b/frontend/tests/e2e/smoke.spec.ts
@@ -33,6 +33,59 @@ async function seedAuthSession(
   }, { authToken: token, authRole: role, structureId: selectedStructureId, structureList: structures });
 }
 
+async function populateRemoteCheckinForms(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const host = document.querySelector('app-remote-checkin');
+    const ngRef = (window as any).ng;
+    if (!host || !ngRef?.getComponent) {
+      throw new Error('RemoteCheckin component instance not available');
+    }
+
+    const component = ngRef.getComponent(host);
+    const now = new Date('2026-02-13T10:00:00.000Z');
+    const expiry = new Date('2028-02-13T10:00:00.000Z');
+    const birthday = new Date('1990-01-15T10:00:00.000Z');
+
+    component.clientForm.patchValue({
+      name: 'Mario',
+      surname: 'Rossi',
+      birthday,
+      street: 'Via Roma',
+      number_city: '10',
+      cap: '00100',
+      telephone: '3331234567',
+      document_type: 'PASSPORT',
+      document_number: 'YA1234567',
+      cf: 'RSSMRA90A15H501U',
+      sesso: '1',
+      nazionalita: 'ITA',
+      email: 'mario.rossi@example.com',
+      comune_nascita_code: 'H501',
+      provincia_nascita: 'RM',
+      stato_nascita: 'ITA',
+      cittadinanza: 'ITA',
+      luogo_emissione: 'H501',
+      data_emissione: now,
+      data_scadenza: expiry,
+      autorita_rilascio: 'Questura',
+      comune_residenza_code: 'H501',
+      provincia_residenza: 'RM',
+      stato_residenza: 'ITA'
+    });
+
+    component.uploadForm.patchValue({
+      frontimage: new File(['front'], 'front.jpg', { type: 'image/jpeg' }),
+      backimage: new File(['back'], 'back.jpg', { type: 'image/jpeg' }),
+      selfie: new File(['selfie'], 'selfie.jpg', { type: 'image/jpeg' })
+    });
+
+    component.clientForm.markAllAsTouched();
+    component.uploadForm.markAllAsTouched();
+    component.clientForm.updateValueAndValidity();
+    component.uploadForm.updateValueAndValidity();
+  });
+}
+
 test.describe('Frontend smoke', () => {
   test('landing page renders core sections and CTA links', async ({ page }) => {
     await page.goto('/landing');
@@ -228,5 +281,87 @@ test.describe('Frontend smoke', () => {
     await page.click('button[type="submit"]');
 
     await expect(page.getByText(/username o password errati/i)).toBeVisible();
+  });
+
+  test('remote check-in submit happy path redirects to completion page', async ({ page }) => {
+    await page.route('**/api/v1/reservations/check/123', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: 123,
+          number_of_people: 2,
+          registered_clients_count: 0,
+          upload_token: 'smoke-upload-token'
+        })
+      });
+    });
+
+    await page.route('**/api/v1/upload', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ message: 'Upload completed' })
+      });
+    });
+
+    await page.goto('/123/remote-checkin/en');
+    await populateRemoteCheckinForms(page);
+    await page.evaluate(() => {
+      const host = document.querySelector('app-remote-checkin');
+      const ngRef = (window as any).ng;
+      if (!host || !ngRef?.getComponent) {
+        throw new Error('RemoteCheckin component instance not available');
+      }
+      const component = ngRef.getComponent(host);
+      component.reservationId = '123';
+      component.canRegister = true;
+      component.uploadToken = 'smoke-upload-token';
+      component.uploadReservationData();
+    });
+
+    await expect(page).toHaveURL(/\/checkin-complete\/123/);
+  });
+
+  test('remote check-in shows localized error when upload token is missing', async ({ page }) => {
+    await page.route('**/api/v1/reservations/check/124', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: 124,
+          number_of_people: 2,
+          registered_clients_count: 0,
+          upload_token: null
+        })
+      });
+    });
+
+    await page.goto('/124/remote-checkin/en');
+    await populateRemoteCheckinForms(page);
+    await page.evaluate(() => {
+      const host = document.querySelector('app-remote-checkin');
+      const ngRef = (window as any).ng;
+      if (!host || !ngRef?.getComponent) {
+        throw new Error('RemoteCheckin component instance not available');
+      }
+      const component = ngRef.getComponent(host);
+      component.reservationId = '124';
+      component.canRegister = true;
+      component.uploadToken = null;
+      component.uploadReservationData();
+    });
+
+    await expect(page.getByText('Unable to continue: upload security token missing. Please refresh and try again.')).toBeVisible();
+  });
+
+  test('landing header language switch updates translated labels', async ({ page }) => {
+    await page.goto('/landing');
+    await expect(page.locator('.header__signin')).toHaveText('Sign in');
+
+    await page.hover('.language-menu');
+    await page.click('.language-menu__list button:has-text("Italiano")');
+
+    await expect(page.locator('.header__signin')).toHaveText('Accedi');
   });
 });

--- a/frontend/tests/e2e/smoke.spec.ts
+++ b/frontend/tests/e2e/smoke.spec.ts
@@ -1,5 +1,12 @@
 import { expect, test } from '@playwright/test';
 
+function buildFakeJwt(expirationOffsetSeconds = 3600): string {
+  const payload = {
+    exp: Math.floor(Date.now() / 1000) + expirationOffsetSeconds
+  };
+  return `header.${Buffer.from(JSON.stringify(payload)).toString('base64url')}.signature`;
+}
+
 test.describe('Frontend smoke', () => {
   test('landing page renders core sections and CTA links', async ({ page }) => {
     await page.goto('/landing');
@@ -29,5 +36,64 @@ test.describe('Frontend smoke', () => {
     await expect(page.locator('app-header .app-header')).toBeVisible();
     await expect(page.locator('.pricing')).toBeVisible();
     await expect(page.locator('.plans')).toBeVisible();
+  });
+
+  test('admin dashboard renders for an authenticated session', async ({ page }) => {
+    await page.addInitScript(({ token }) => {
+      localStorage.setItem('admin_token', token);
+      localStorage.setItem('selected_structure_id', '1');
+      localStorage.setItem('user', JSON.stringify({
+        id: 1,
+        username: 'smoke-admin',
+        role: 'admin',
+        structures: [{ id: 1, name: 'Smoke Structure' }]
+      }));
+    }, { token: buildFakeJwt() });
+
+    await page.route('**/api/v1/reservations/structure/*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([{
+          reservation_id: 101,
+          name_reference: 'Smoke Guest',
+          room_name: 'Room A',
+          start_date: '2026-02-10',
+          end_date: '2026-02-12',
+          status: 'Pending',
+          id_reference: 'SMK101'
+        }])
+      });
+    });
+
+    await page.route('**/api/v1/reservations/monthly/*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([{ total_reservations: 1 }])
+      });
+    });
+
+    await page.goto('/admin/dashboard');
+    await expect(page).toHaveURL(/\/admin\/dashboard/);
+    await expect(page.locator('.stats-grid')).toBeVisible();
+    await expect(page.locator('p-table')).toBeVisible();
+  });
+
+  test('admin login shows error toast on invalid credentials', async ({ page }) => {
+    await page.route('**/api/v1/admin/login', async (route) => {
+      await route.fulfill({
+        status: 401,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: 'Invalid credentials' })
+      });
+    });
+
+    await page.goto('/admin/login');
+    await page.fill('#username', 'wrong-user');
+    await page.fill('#password', 'wrong-password');
+    await page.click('button[type="submit"]');
+
+    await expect(page.getByText(/username o password errati/i)).toBeVisible();
   });
 });

--- a/frontend/tests/e2e/smoke.spec.ts
+++ b/frontend/tests/e2e/smoke.spec.ts
@@ -280,7 +280,7 @@ test.describe('Frontend smoke', () => {
     await page.fill('#password', 'wrong-password');
     await page.click('button[type="submit"]');
 
-    await expect(page.getByText(/username o password errati/i)).toBeVisible();
+    await expect(page.locator('.p-toast-message.p-toast-message-error')).toBeVisible();
   });
 
   test('create reservation submits and redirects to dashboard', async ({ page }) => {

--- a/frontend/tests/e2e/smoke.spec.ts
+++ b/frontend/tests/e2e/smoke.spec.ts
@@ -1,10 +1,36 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
 
 function buildFakeJwt(expirationOffsetSeconds = 3600): string {
   const payload = {
     exp: Math.floor(Date.now() / 1000) + expirationOffsetSeconds
   };
   return `header.${Buffer.from(JSON.stringify(payload)).toString('base64url')}.signature`;
+}
+
+async function seedAuthSession(
+  page: Page,
+  role: 'admin' | 'superadmin',
+  options?: { selectedStructureId?: string | null; structures?: Array<{ id: number; name: string }> }
+): Promise<void> {
+  const token = buildFakeJwt();
+  const selectedStructureId = options?.selectedStructureId === undefined ? '1' : options.selectedStructureId;
+  const structures = options?.structures ?? [{ id: 1, name: 'Smoke Structure' }];
+  await page.addInitScript(({ authToken, authRole, structureId, structureList }) => {
+    localStorage.setItem('admin_token', authToken);
+    localStorage.setItem('appLang', 'en');
+    localStorage.setItem('remote-checkin-lang', 'en');
+    if (structureId) {
+      localStorage.setItem('selected_structure_id', structureId);
+    } else {
+      localStorage.removeItem('selected_structure_id');
+    }
+    localStorage.setItem('user', JSON.stringify({
+      id: 1,
+      username: 'smoke-admin',
+      role: authRole,
+      structures: structureList
+    }));
+  }, { authToken: token, authRole: role, structureId: selectedStructureId, structureList: structures });
 }
 
 test.describe('Frontend smoke', () => {
@@ -39,16 +65,7 @@ test.describe('Frontend smoke', () => {
   });
 
   test('admin dashboard renders for an authenticated session', async ({ page }) => {
-    await page.addInitScript(({ token }) => {
-      localStorage.setItem('admin_token', token);
-      localStorage.setItem('selected_structure_id', '1');
-      localStorage.setItem('user', JSON.stringify({
-        id: 1,
-        username: 'smoke-admin',
-        role: 'admin',
-        structures: [{ id: 1, name: 'Smoke Structure' }]
-      }));
-    }, { token: buildFakeJwt() });
+    await seedAuthSession(page, 'admin');
 
     await page.route('**/api/v1/reservations/structure/*', async (route) => {
       await route.fulfill({
@@ -78,6 +95,122 @@ test.describe('Frontend smoke', () => {
     await expect(page).toHaveURL(/\/admin\/dashboard/);
     await expect(page.locator('.stats-grid')).toBeVisible();
     await expect(page.locator('p-table')).toBeVisible();
+  });
+
+  test('auth guard redirects unauthenticated access from dashboard to login', async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.removeItem('admin_token');
+      localStorage.removeItem('user');
+      localStorage.removeItem('selected_structure_id');
+    });
+
+    await page.goto('/admin/dashboard');
+    await expect(page).toHaveURL(/\/admin\/login/);
+    await expect(page.locator('form')).toBeVisible();
+  });
+
+  test('dashboard shows no-structure state when selected_structure_id is missing', async ({ page }) => {
+    await seedAuthSession(page, 'admin', {
+      selectedStructureId: null,
+      structures: []
+    });
+
+    let reservationCalls = 0;
+    let monthlyCalls = 0;
+    await page.route('**/api/v1/reservations/structure/*', async (route) => {
+      reservationCalls += 1;
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) });
+    });
+    await page.route('**/api/v1/reservations/monthly/*', async (route) => {
+      monthlyCalls += 1;
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([{ total_reservations: 0 }]) });
+    });
+
+    await page.goto('/admin/dashboard');
+    await expect(page).toHaveURL(/\/admin\/dashboard/);
+    await page.waitForTimeout(300);
+    expect(reservationCalls).toBe(0);
+    expect(monthlyCalls).toBe(0);
+    await expect(page.locator('.stats-grid')).toBeVisible();
+  });
+
+  test('reservation details redirects to dashboard when reservation belongs to another structure', async ({ page }) => {
+    await seedAuthSession(page, 'admin', {
+      selectedStructureId: '1',
+      structures: [{ id: 1, name: 'Main Structure' }]
+    });
+
+    await page.route('**/api/v1/reservations/admin/127', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: 127,
+          id_reference: 'RES-127',
+          name_reference: 'Other Structure Guest',
+          status: 'Pending',
+          room: {
+            id: 30,
+            id_structure: 2,
+            name: 'Room X'
+          }
+        })
+      });
+    });
+    await page.route('**/api/v1/rooms**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([])
+      });
+    });
+    await page.route('**/api/v1/reservations/structure/*', async (route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) });
+    });
+    await page.route('**/api/v1/reservations/monthly/*', async (route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([{ total_reservations: 0 }]) });
+    });
+
+    await page.goto('/admin/reservation-details/127');
+    await expect(page).toHaveURL(/\/admin\/dashboard/);
+  });
+
+  test('superadmin route is denied for admin role and allowed for superadmin role', async ({ page }) => {
+    await seedAuthSession(page, 'admin');
+    await page.route('**/api/v1/reservations/structure/*', async (route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) });
+    });
+    await page.route('**/api/v1/reservations/monthly/*', async (route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([{ total_reservations: 0 }]) });
+    });
+
+    await page.goto('/admin/superadmin/dashboard');
+    await expect(page).toHaveURL(/\/admin\/dashboard/);
+
+    await seedAuthSession(page, 'superadmin', {
+      selectedStructureId: null,
+      structures: []
+    });
+    await page.route('**/api/v1/superadmin/dashboard', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          dashboard: {
+            total_structures: 1,
+            active_structures: 1,
+            archived_structures: 0,
+            total_users: 1,
+            unassigned_admins: 0,
+            total_reservations: 5
+          }
+        })
+      });
+    });
+
+    await page.goto('/admin/superadmin/dashboard');
+    await expect(page).toHaveURL(/\/admin\/superadmin\/dashboard/);
+    await expect(page.locator('.dashboard')).toBeVisible();
   });
 
   test('admin login shows error toast on invalid credentials', async ({ page }) => {

--- a/frontend/tests/e2e/smoke.spec.ts
+++ b/frontend/tests/e2e/smoke.spec.ts
@@ -283,6 +283,105 @@ test.describe('Frontend smoke', () => {
     await expect(page.getByText(/username o password errati/i)).toBeVisible();
   });
 
+  test('create reservation submits and redirects to dashboard', async ({ page }) => {
+    await seedAuthSession(page, 'admin', {
+      selectedStructureId: '1',
+      structures: [{ id: 1, name: 'Main Structure' }]
+    });
+
+    await page.route('**/api/v1/rooms**', async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([{ id: 11, id_structure: 1, name: 'Room 11', capacity: 3, is_active: true }])
+        });
+        return;
+      }
+      await route.continue();
+    });
+
+    await page.route('**/api/v1/reservations', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ id: 301, id_reference: 'RES301' })
+      });
+    });
+
+    await page.goto('/admin/create-reservation');
+    await page.evaluate(() => {
+      const host = document.querySelector('app-create-reservation');
+      const ngRef = (window as any).ng;
+      if (!host || !ngRef?.getComponent) {
+        throw new Error('CreateReservation component instance not available');
+      }
+      const component = ngRef.getComponent(host);
+      component.reservationForm.patchValue({
+        reservationNumber: 'RES301',
+        startDate: new Date('2026-02-20T10:00:00.000Z'),
+        endDate: new Date('2026-02-22T10:00:00.000Z'),
+        roomName: { id: 11, id_structure: 1, name: 'Room 11', capacity: 3 },
+        nameReference: 'Smoke Guest',
+        email: 'smoke@example.com',
+        telephone: '3331234567',
+        numberOfPeople: 2
+      });
+      component.onSubmit();
+    });
+
+    await expect(page).toHaveURL(/\/admin\/dashboard/);
+  });
+
+  test('rooms page supports search and row status toggle only in edit mode', async ({ page }) => {
+    await seedAuthSession(page, 'admin', {
+      selectedStructureId: '1',
+      structures: [{ id: 1, name: 'Main Structure' }]
+    });
+
+    let editCalls = 0;
+    await page.route('**/api/v1/rooms**', async (route) => {
+      const method = route.request().method();
+      if (method === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([
+            { id: 1, id_structure: 1, name: 'Blue Room', capacity: 2, is_active: true },
+            { id: 2, id_structure: 1, name: 'Red Room', capacity: 4, is_active: true }
+          ])
+        });
+        return;
+      }
+      if (method === 'PUT') {
+        editCalls += 1;
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: route.request().postData() || '{}'
+        });
+        return;
+      }
+      await route.continue();
+    });
+
+    await page.goto('/admin/rooms');
+    await expect(page.getByText('Blue Room')).toBeVisible();
+    await page.fill('#roomSearch', 'Blue');
+    await expect(page.getByText('Blue Room')).toBeVisible();
+    await expect(page.getByText('Red Room')).not.toBeVisible();
+
+    const firstStatusPill = page.locator('.status-pill').first();
+    await expect(firstStatusPill).toBeDisabled();
+    await firstStatusPill.click({ force: true });
+    expect(editCalls).toBe(0);
+
+    await page.getByRole('button', { name: /edit/i }).first().click();
+    await expect(firstStatusPill).toBeEnabled();
+    await firstStatusPill.click();
+    expect(editCalls).toBe(1);
+  });
+
   test('remote check-in submit happy path redirects to completion page', async ({ page }) => {
     await page.route('**/api/v1/reservations/check/123', async (route) => {
       await route.fulfill({


### PR DESCRIPTION
## Summary

This PR strengthens frontend quality gates by introducing and expanding Playwright smoke E2E coverage, plus stabilizing i18n runtime behavior observed during smoke runs.

## What was implemented

### 1) Playwright smoke setup on frontend PRs
- Added Playwright smoke test infrastructure and CI workflow for frontend PR checks.
- New workflow runs smoke tests and uploads HTML artifacts for review.

### 2) Expanded smoke E2E coverage
Added/updated smoke scenarios for:

- Public pages:
  - Landing render sanity
  - Pricing render sanity
  - Header language switch (EN -> IT) updates translated labels

- Auth/authorization:
  - Unauthenticated `/admin/dashboard` redirects to `/admin/login`
  - Superadmin route guard:
    - admin user denied/redirected
    - superadmin user allowed

- Admin dashboard/security UX:
  - Dashboard renders with authenticated mocked session
  - No-structure admin scenario remains stable without data-fetch calls
  - Reservation details structure isolation redirects to dashboard when mismatch

- Admin flows:
  - Create reservation happy path submits and redirects to dashboard
  - Rooms page:
    - search filter behavior
    - status toggle blocked outside edit mode
    - status toggle works in edit mode

- Remote check-in:
  - Happy path submit redirects to completion page
  - Missing upload token shows localized error path

### 3) Translation and runtime fallback cleanup
- Added missing i18n keys in locale files for runtime warnings seen in smoke runs.
- Suppressed Transloco missing-key noise via app config for cleaner test logs.
- Refactored pricing translation usage:
  - moved pricing/comparison string translation resolution from TS to template (`| transloco`)
  - avoids eager TS translation calls that can trigger runtime fallback warnings.

### 4) Repository hygiene
- Added generated runtime/test output folders to `.gitignore`:
  - `frontend/coverage/`
  - `frontend/playwright-report/`
  - `frontend/test-results/`
  - `uploads/`

## Validation

- Ran smoke suite locally:
  - `npm run e2e:smoke`
  - Result: all smoke tests passing (expanded suite)

## Notes

- Smoke tests are intentionally mostly backend-independent via route mocking where appropriate.
- This keeps PR checks fast and deterministic while still validating critical user journeys and guards.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added automated end-to-end and unit test workflows to ensure code quality and reliability.

* **Improvements**
  * Updated pricing page display to show numeric values with currency formatting.
  * Enhanced internationalization with new translation keys for German, Spanish, and French.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->