### PR TITLE
chore(ci): run workflows based on file changes

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -2,6 +2,8 @@ name: Backend Tests
 
 on:
   pull_request:
+    paths:
+      - 'backend/**'
     branches:
       - dev
     types:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,9 @@ name: Build Flask and Angular with Docker
 
 on:
   push:
+    paths:
+      - 'backend/**'
+      - 'frontend/**'
     branches:
       - dev
   workflow_call:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,9 @@ on:
 #      - completed
 
   push:
+    paths:
+      - 'backend/**'
+      - 'frontend/**'
     branches:
       - dev  # This ensures it runs only when changes are pushed to dev (e.g., after a PR merge)
   workflow_dispatch:
@@ -15,8 +18,6 @@ jobs:
   compile:
     name: Compile Angular and Flask
     uses: ./.github/workflows/build.yml
-
-
 
   deploy-images:
     environment: pre-prod
@@ -34,7 +35,6 @@ jobs:
 #          run-id: ${{ github.event.workflow_run.id }}
 #          github-token: ${{ secrets.GITHUB_TOKEN }}
 
-
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -50,8 +50,7 @@ jobs:
           else
             echo "TAG=alpha" >> $GITHUB_ENV
           fi
-
-          
+ 
       - name: Create folder
         run: mkdir -p frontend/dist/remote-checkin
 

--- a/.github/workflows/frontend-e2e.yml
+++ b/.github/workflows/frontend-e2e.yml
@@ -2,6 +2,8 @@ name: Frontend E2E Smoke
 
 on:
   pull_request:
+    paths:
+      - 'frontend/**'
     branches:
       - dev
     types:

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -2,6 +2,8 @@ name: Frontend Tests
 
 on:
   pull_request:
+    paths:
+      - 'frontend/**'
     branches:
       - dev
     types:

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,10 +2,14 @@ name: Pylint
 
 on:
   push:
+    paths:
+      - 'backend/**'
     branches:
       - main
       - dev
   pull_request:
+    paths:
+      - 'backend/**'
     branches:
       - main
       - dev


### PR DESCRIPTION
This PR updates your workflows so that they run based on file changes. This way, you can prevent unwanted execution (e.g., the backend/frontend CI workflow runs when you update the README).